### PR TITLE
Wildfly compatibility for Kafka Connector

### DIFF
--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaActivationSpec.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaActivationSpec.java
@@ -48,9 +48,6 @@ import javax.resource.spi.Activation;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.InvalidPropertyException;
 import javax.resource.spi.ResourceAdapter;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Properties;
 
 /**
@@ -59,37 +56,11 @@ import java.util.Properties;
 @Activation(messageListeners = KafkaListener.class)
 public class KafkaActivationSpec implements ActivationSpec {
 
-    private static final String[] PROPERTIES = {
-            "autoCommitInterval",
-            "bootstrapServersConfig",
-            "clientId",
-            "enableAutoCommit",
-            "groupIdConfig",
-            "valueDeserializer",
-            "keyDeserializer",
-            "topics",
-            "pollInterval",
-            "initialPollDelay",
-            "fetchMinBytes",
-            "fetchMaxBytes",
-            "heartbeatInterval",
-            "maxPartitionFetchBytes",
-            "sessionTimeout",
-            "autoOffsetReset",
-            "connectionsMaxIdle",
-            "receiveBuffer",
-            "requestTimeout",
-            "checkCRCs",
-            "fetchMaxWait",
-            "metadataMaxAge",
-            "reconnectBackoff",
-            "retryBackoff",
-            "additionalProperties"
-    };
-
     private final Properties consumerProperties;
     private AdditionalPropertiesParser additionalPropertiesParser;
+
     private ResourceAdapter ra;
+
     private Long autoCommitInterval;
     private String bootstrapServersConfig;
     private String clientId;
@@ -115,47 +86,9 @@ public class KafkaActivationSpec implements ActivationSpec {
     private Long reconnectBackoff;
     private Long retryBackoff;
     private String additionalProperties;
-    private String systemPropertyPrefix;
 
     public KafkaActivationSpec() {
         consumerProperties = new Properties();
-    }
-
-    public String getSystemPropertyPrefix() {
-        return systemPropertyPrefix;
-    }
-
-    public void setSystemPropertyPrefix(String systemPropertyPrefix) {
-        this.systemPropertyPrefix = systemPropertyPrefix;
-        try {
-            for (String name : PROPERTIES) {
-                String value = System.getProperty(systemPropertyPrefix + "." + name);
-
-                if (value != null) {
-                    final Field field = KafkaActivationSpec.class.getDeclaredField(name);
-                    final Method setter = KafkaActivationSpec.class.getMethod(
-                            "set" + name.substring(0, 1).toUpperCase() + name.substring(1),
-                            field.getType());
-
-                    setter.invoke(this, objectToType(value, field.getType()));
-                }
-            }
-        } catch (NoSuchFieldException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalArgumentException("Failed parsing system properties: ", e);
-        }
-    }
-
-    private Object objectToType(String value, Class<?> type) {
-        if (Long.class.equals(type))
-            return Long.getLong(value);
-
-        if (Integer.class.equals(type))
-            return Integer.getInteger(value);
-
-        if (Boolean.class.equals(type))
-            return Boolean.getBoolean(value);
-
-        return value;
     }
 
     @Override
@@ -256,8 +189,8 @@ public class KafkaActivationSpec implements ActivationSpec {
 
     public Properties getConsumerProperties() {
         return additionalPropertiesParser == null
-                ? consumerProperties
-                : AdditionalPropertiesParser.merge(consumerProperties, additionalPropertiesParser.parse());
+                    ? consumerProperties
+                    : AdditionalPropertiesParser.merge(consumerProperties, additionalPropertiesParser.parse());
     }
 
     public String getTopics() {

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaActivationSpec.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaActivationSpec.java
@@ -48,6 +48,9 @@ import javax.resource.spi.Activation;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.InvalidPropertyException;
 import javax.resource.spi.ResourceAdapter;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Properties;
 
 /**
@@ -56,11 +59,37 @@ import java.util.Properties;
 @Activation(messageListeners = KafkaListener.class)
 public class KafkaActivationSpec implements ActivationSpec {
 
+    private static final String[] PROPERTIES = {
+            "autoCommitInterval",
+            "bootstrapServersConfig",
+            "clientId",
+            "enableAutoCommit",
+            "groupIdConfig",
+            "valueDeserializer",
+            "keyDeserializer",
+            "topics",
+            "pollInterval",
+            "initialPollDelay",
+            "fetchMinBytes",
+            "fetchMaxBytes",
+            "heartbeatInterval",
+            "maxPartitionFetchBytes",
+            "sessionTimeout",
+            "autoOffsetReset",
+            "connectionsMaxIdle",
+            "receiveBuffer",
+            "requestTimeout",
+            "checkCRCs",
+            "fetchMaxWait",
+            "metadataMaxAge",
+            "reconnectBackoff",
+            "retryBackoff",
+            "additionalProperties"
+    };
+
     private final Properties consumerProperties;
     private AdditionalPropertiesParser additionalPropertiesParser;
-
     private ResourceAdapter ra;
-
     private Long autoCommitInterval;
     private String bootstrapServersConfig;
     private String clientId;
@@ -86,9 +115,47 @@ public class KafkaActivationSpec implements ActivationSpec {
     private Long reconnectBackoff;
     private Long retryBackoff;
     private String additionalProperties;
+    private String systemPropertyPrefix;
 
     public KafkaActivationSpec() {
         consumerProperties = new Properties();
+    }
+
+    public String getSystemPropertyPrefix() {
+        return systemPropertyPrefix;
+    }
+
+    public void setSystemPropertyPrefix(String systemPropertyPrefix) {
+        this.systemPropertyPrefix = systemPropertyPrefix;
+        try {
+            for (String name : PROPERTIES) {
+                String value = System.getProperty(systemPropertyPrefix + "." + name);
+
+                if (value != null) {
+                    final Field field = KafkaActivationSpec.class.getDeclaredField(name);
+                    final Method setter = KafkaActivationSpec.class.getMethod(
+                            "set" + name.substring(0, 1).toUpperCase() + name.substring(1),
+                            field.getType());
+
+                    setter.invoke(this, objectToType(value, field.getType()));
+                }
+            }
+        } catch (NoSuchFieldException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalArgumentException("Failed parsing system properties: ", e);
+        }
+    }
+
+    private Object objectToType(String value, Class<?> type) {
+        if (Long.class.equals(type))
+            return Long.getLong(value);
+
+        if (Integer.class.equals(type))
+            return Integer.getInteger(value);
+
+        if (Boolean.class.equals(type))
+            return Boolean.getBoolean(value);
+
+        return value;
     }
 
     @Override
@@ -189,8 +256,8 @@ public class KafkaActivationSpec implements ActivationSpec {
 
     public Properties getConsumerProperties() {
         return additionalPropertiesParser == null
-                    ? consumerProperties
-                    : AdditionalPropertiesParser.merge(consumerProperties, additionalPropertiesParser.parse());
+                ? consumerProperties
+                : AdditionalPropertiesParser.merge(consumerProperties, additionalPropertiesParser.parse());
     }
 
     public String getTopics() {

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaResourceAdapter.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaResourceAdapter.java
@@ -124,17 +124,11 @@ public class KafkaResourceAdapter implements ResourceAdapter, Serializable{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        KafkaResourceAdapter that = (KafkaResourceAdapter) o;
-        return Objects.equals(context, that.context) &&
-                Objects.equals(registeredFactories, that.registeredFactories) &&
-                Objects.equals(poller, that.poller);
+       return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(context, registeredFactories, poller);
+        return super.hashCode();
     }
 }

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaResourceAdapter.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaResourceAdapter.java
@@ -41,6 +41,7 @@ package fish.payara.cloud.connectors.kafka.inbound;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -120,5 +121,20 @@ public class KafkaResourceAdapter implements ResourceAdapter, Serializable{
     public XAResource[] getXAResources(ActivationSpec[] specs) throws ResourceException {
         return null;
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KafkaResourceAdapter that = (KafkaResourceAdapter) o;
+        return Objects.equals(context, that.context) &&
+                Objects.equals(registeredFactories, that.registeredFactories) &&
+                Objects.equals(poller, that.poller);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(context, registeredFactories, poller);
+    }
 }

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaResourceAdapter.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaResourceAdapter.java
@@ -41,7 +41,6 @@ package fish.payara.cloud.connectors.kafka.inbound;
 
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/outbound/KafkaManagedConnection.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/outbound/KafkaManagedConnection.java
@@ -40,27 +40,22 @@
 package fish.payara.cloud.connectors.kafka.outbound;
 
 import fish.payara.cloud.connectors.kafka.api.KafkaConnection;
-import java.io.PrintWriter;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.Future;
-import javax.resource.NotSupportedException;
-import javax.resource.ResourceException;
-import javax.resource.spi.ConnectionEvent;
-import javax.resource.spi.ConnectionEventListener;
-import javax.resource.spi.ConnectionRequestInfo;
-import javax.resource.spi.LocalTransaction;
-import javax.resource.spi.ManagedConnection;
-import javax.resource.spi.ManagedConnectionMetaData;
-import javax.security.auth.Subject;
-import javax.transaction.xa.XAResource;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.PartitionInfo;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.spi.*;
+import javax.security.auth.Subject;
+import javax.transaction.xa.XAResource;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Future;
 
 /**
  *
@@ -170,8 +165,10 @@ public class KafkaManagedConnection implements ManagedConnection, KafkaConnectio
     
     void remove(KafkaConnectionImpl conn) {
         connectionHandles.remove(conn);
+        ConnectionEvent event = new ConnectionEvent(this, ConnectionEvent.CONNECTION_CLOSED);
+        event.setConnectionHandle(conn);
         for (ConnectionEventListener listener : listeners) {
-            listener.connectionClosed(new ConnectionEvent(this,ConnectionEvent.CONNECTION_CLOSED));
+            listener.connectionClosed(event);
         }
     }
     

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/outbound/KafkaManagedConnectionFactory.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/outbound/KafkaManagedConnectionFactory.java
@@ -43,6 +43,7 @@ import fish.payara.cloud.connectors.kafka.api.KafkaConnectionFactory;
 import fish.payara.cloud.connectors.kafka.api.KafkaConnection;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import javax.resource.ResourceException;
@@ -381,4 +382,37 @@ public class KafkaManagedConnectionFactory implements ManagedConnectionFactory, 
         return writer;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KafkaManagedConnectionFactory that = (KafkaManagedConnectionFactory) o;
+        return Objects.equals(producerProperties, that.producerProperties) &&
+                Objects.equals(bootstrapServersConfig, that.bootstrapServersConfig) &&
+                Objects.equals(clientId, that.clientId) &&
+                Objects.equals(valueSerializer, that.valueSerializer) &&
+                Objects.equals(keySerializer, that.keySerializer) &&
+                Objects.equals(bufferMemory, that.bufferMemory) &&
+                Objects.equals(acks, that.acks) &&
+                Objects.equals(retries, that.retries) &&
+                Objects.equals(batchSize, that.batchSize) &&
+                Objects.equals(lingerMS, that.lingerMS) &&
+                Objects.equals(maxBlockMS, that.maxBlockMS) &&
+                Objects.equals(maxRequestSize, that.maxRequestSize) &&
+                Objects.equals(receiveBufferBytes, that.receiveBufferBytes) &&
+                Objects.equals(requestTimeout, that.requestTimeout) &&
+                Objects.equals(compression, that.compression) &&
+                Objects.equals(connectionsMaxIdle, that.connectionsMaxIdle) &&
+                Objects.equals(maxInflightConnections, that.maxInflightConnections) &&
+                Objects.equals(metadataMaxAge, that.metadataMaxAge) &&
+                Objects.equals(retryBackoff, that.retryBackoff) &&
+                Objects.equals(reconnectBackoff, that.reconnectBackoff) &&
+                Objects.equals(additionalProperties, that.additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(producerProperties, bootstrapServersConfig, clientId, valueSerializer, keySerializer, bufferMemory, acks, retries, batchSize, lingerMS, maxBlockMS, maxRequestSize, receiveBufferBytes, requestTimeout, compression, connectionsMaxIdle, maxInflightConnections, metadataMaxAge, retryBackoff, reconnectBackoff, additionalProperties);
+    }
 }


### PR DESCRIPTION
Hi ,

first - thanks a lot for the nice reference implementation.

Not sure if this is interesting for you, but I am currently running on Wildfly and had to make some small changes to get the resource adapter running on Wildfly (only handled Kafka, because it's the only one interesting for me at the moment, but same patterns will probably apply to other connectors as well).

Explanation:
* Wildfly Validator is explicit about the sentence in JCA spec where ManagedConnectionFactory and ResourceAdapter must provide own implementation of hashCode and equals.
* Wildfly invokes Work.release() which leads to an InvalidHandleException when the final block in the Work.run tries to do so

Feel free to merge / reject.

Best regards
Ladi