### PR TITLE
System property override for Inbound Kafka Connector

### DIFF
--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaActivationSpec.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaActivationSpec.java
@@ -41,6 +41,7 @@ package fish.payara.cloud.connectors.kafka.inbound;
 
 import fish.payara.cloud.connectors.kafka.api.KafkaListener;
 import fish.payara.cloud.connectors.kafka.tools.AdditionalPropertiesParser;
+import fish.payara.cloud.connectors.kafka.tools.SystemPropertiesParser;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import javax.resource.ResourceException;
@@ -56,11 +57,36 @@ import java.util.Properties;
 @Activation(messageListeners = KafkaListener.class)
 public class KafkaActivationSpec implements ActivationSpec {
 
+    private final SystemPropertiesParser systemPropertiesParser = new SystemPropertiesParser(
+            "autoCommitInterval",
+            "bootstrapServersConfig",
+            "clientId",
+            "enableAutoCommit",
+            "groupIdConfig",
+            "valueDeserializer",
+            "keyDeserializer",
+            "topics",
+            "pollInterval",
+            "initialPollDelay",
+            "fetchMinBytes",
+            "fetchMaxBytes",
+            "heartbeatInterval",
+            "maxPartitionFetchBytes",
+            "sessionTimeout",
+            "autoOffsetReset",
+            "connectionsMaxIdle",
+            "receiveBuffer",
+            "requestTimeout",
+            "checkCRCs",
+            "fetchMaxWait",
+            "metadataMaxAge",
+            "reconnectBackoff",
+            "retryBackoff",
+            "additionalProperties");
+
     private final Properties consumerProperties;
     private AdditionalPropertiesParser additionalPropertiesParser;
-
     private ResourceAdapter ra;
-
     private Long autoCommitInterval;
     private String bootstrapServersConfig;
     private String clientId;
@@ -86,9 +112,19 @@ public class KafkaActivationSpec implements ActivationSpec {
     private Long reconnectBackoff;
     private Long retryBackoff;
     private String additionalProperties;
+    private String systemPropertyPrefix;
 
     public KafkaActivationSpec() {
         consumerProperties = new Properties();
+    }
+
+    public String getSystemPropertyPrefix() {
+        return systemPropertyPrefix;
+    }
+
+    public void setSystemPropertyPrefix(String systemPropertyPrefix) {
+        this.systemPropertyPrefix = systemPropertyPrefix;
+        systemPropertiesParser.applySystemProperties(this, systemPropertyPrefix);
     }
 
     @Override

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParser.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParser.java
@@ -1,0 +1,49 @@
+package fish.payara.cloud.connectors.kafka.tools;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class SystemPropertiesParser {
+    private final String[] propertyNames;
+
+    public SystemPropertiesParser(String... propertyNames) {
+
+        this.propertyNames = propertyNames;
+    }
+
+    public void applySystemProperties(Object instance, String prefix) {
+        try {
+            for (String name : propertyNames) {
+                String value = System.getProperty(prefix + "." + name);
+
+                if (value != null) {
+                    final Field field = instance.getClass().getDeclaredField(name);
+                    final Method setter = instance.getClass().getMethod(
+                            "set" + name.substring(0, 1).toUpperCase() + name.substring(1),
+                            field.getType());
+
+                    setter.invoke(instance, objectToType(value, field.getType()));
+                }
+            }
+        } catch (NoSuchFieldException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalArgumentException("Failed parsing system properties: ", e);
+        }
+
+    }
+
+    private Object objectToType(String value, Class<?> type) {
+        if (Long.class.equals(type))
+            return Long.parseLong(value);
+
+        if (Integer.class.equals(type))
+            return Integer.parseInt(value);
+
+        if (Boolean.class.equals(type))
+            return Boolean.getBoolean(value);
+
+        return value;
+    }
+
+
+}

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParser.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParser.java
@@ -1,9 +1,51 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.cloud.connectors.kafka.tools;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+/**
+ * @author Ladislav Petera
+ */
 public class SystemPropertiesParser {
     private final String[] propertyNames;
 

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParser.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParser.java
@@ -82,7 +82,7 @@ public class SystemPropertiesParser {
             return Integer.parseInt(value);
 
         if (Boolean.class.equals(type))
-            return Boolean.getBoolean(value);
+            return Boolean.parseBoolean(value);
 
         return value;
     }

--- a/Kafka/KafkaJCAAPI/src/test/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParserTest.java
+++ b/Kafka/KafkaJCAAPI/src/test/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParserTest.java
@@ -12,12 +12,13 @@ public class SystemPropertiesParserTest {
     public static final String INT_PROPERTY = "intProperty";
     public static final String PREFIX = "prefix";
     public static final String UNKNOWN_PROPERTY = "unknown";
+    private static final String BOOL_PROPERTY = "boolProperty";
     private SystemPropertiesParser parser;
     private TestObject testObject;
 
     @BeforeMethod
     public void setUp() {
-        parser = new SystemPropertiesParser(LONG_PROPERTY, STRING_PROPERTY, INT_PROPERTY);
+        parser = new SystemPropertiesParser(LONG_PROPERTY, STRING_PROPERTY, INT_PROPERTY, BOOL_PROPERTY);
         testObject = new TestObject();
     }
 
@@ -26,6 +27,7 @@ public class SystemPropertiesParserTest {
         System.clearProperty(PREFIX + "." + LONG_PROPERTY);
         System.clearProperty(PREFIX + "."+ STRING_PROPERTY);
         System.clearProperty(PREFIX + "."+ INT_PROPERTY);
+        System.clearProperty(PREFIX + "."+ BOOL_PROPERTY);
     }
 
     @Test
@@ -49,6 +51,13 @@ public class SystemPropertiesParserTest {
         assertEquals(testObject.getIntProperty(), Integer.valueOf(15));
     }
 
+    @Test
+    public void checkBoolProperty() {
+        System.setProperty(PREFIX + "." + BOOL_PROPERTY, Boolean.TRUE.toString());
+        parser.applySystemProperties(testObject, PREFIX);
+        assertEquals(testObject.getBoolProperty(), Boolean.TRUE);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void invalidValueType() {
         System.setProperty(PREFIX + "." + INT_PROPERTY, "Hello");
@@ -65,6 +74,7 @@ public class SystemPropertiesParserTest {
         private Long longProperty;
         private String stringProperty;
         private Integer intProperty;
+        private Boolean boolProperty;
 
         public Long getLongProperty() {
             return longProperty;
@@ -88,6 +98,14 @@ public class SystemPropertiesParserTest {
 
         public void setIntProperty(Integer intProperty) {
             this.intProperty = intProperty;
+        }
+
+        public Boolean getBoolProperty() {
+            return boolProperty;
+        }
+
+        public void setBoolProperty(Boolean boolProperty) {
+            this.boolProperty = boolProperty;
         }
     }
 }

--- a/Kafka/KafkaJCAAPI/src/test/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParserTest.java
+++ b/Kafka/KafkaJCAAPI/src/test/java/fish/payara/cloud/connectors/kafka/tools/SystemPropertiesParserTest.java
@@ -1,0 +1,93 @@
+package fish.payara.cloud.connectors.kafka.tools;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class SystemPropertiesParserTest {
+    public static final String LONG_PROPERTY = "longProperty";
+    public static final String STRING_PROPERTY = "stringProperty";
+    public static final String INT_PROPERTY = "intProperty";
+    public static final String PREFIX = "prefix";
+    public static final String UNKNOWN_PROPERTY = "unknown";
+    private SystemPropertiesParser parser;
+    private TestObject testObject;
+
+    @BeforeMethod
+    public void setUp() {
+        parser = new SystemPropertiesParser(LONG_PROPERTY, STRING_PROPERTY, INT_PROPERTY);
+        testObject = new TestObject();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(PREFIX + "." + LONG_PROPERTY);
+        System.clearProperty(PREFIX + "."+ STRING_PROPERTY);
+        System.clearProperty(PREFIX + "."+ INT_PROPERTY);
+    }
+
+    @Test
+    public void checkLongProperty() {
+        System.setProperty(PREFIX + "." + LONG_PROPERTY, Long.toString(10L));
+        parser.applySystemProperties(testObject, PREFIX);
+        assertEquals(testObject.getLongProperty(), Long.valueOf(10L));
+    }
+
+    @Test
+    public void checkStringProperty() {
+        System.setProperty(PREFIX + "." + STRING_PROPERTY, "ABC");
+        parser.applySystemProperties(testObject, PREFIX);
+        assertEquals(testObject.getStringProperty(), "ABC");
+    }
+
+    @Test
+    public void checkIntProperty() {
+        System.setProperty(PREFIX + "." + INT_PROPERTY, Integer.toString(15));
+        parser.applySystemProperties(testObject, PREFIX);
+        assertEquals(testObject.getIntProperty(), Integer.valueOf(15));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void invalidValueType() {
+        System.setProperty(PREFIX + "." + INT_PROPERTY, "Hello");
+        parser.applySystemProperties(testObject, PREFIX);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void missingProperty() {
+        System.setProperty(PREFIX + "." + UNKNOWN_PROPERTY, Integer.toString(15));
+        new SystemPropertiesParser(UNKNOWN_PROPERTY).applySystemProperties(testObject, PREFIX);
+    }
+
+    private static class TestObject {
+        private Long longProperty;
+        private String stringProperty;
+        private Integer intProperty;
+
+        public Long getLongProperty() {
+            return longProperty;
+        }
+
+        public void setLongProperty(Long longProperty) {
+            this.longProperty = longProperty;
+        }
+
+        public String getStringProperty() {
+            return stringProperty;
+        }
+
+        public void setStringProperty(String stringProperty) {
+            this.stringProperty = stringProperty;
+        }
+
+        public Integer getIntProperty() {
+            return intProperty;
+        }
+
+        public void setIntProperty(Integer intProperty) {
+            this.intProperty = intProperty;
+        }
+    }
+}

--- a/Kafka/README.md
+++ b/Kafka/README.md
@@ -86,6 +86,48 @@ public class KafkaMDB implements KafkaListener {
 }
 ```
 
+### Inbound configuration via system properties
+ 
+ Sometimes you wish to have some properties like *bootstrapServersConfig* configurable via
+ the application server admin console instead of having them hardcoded in you software.
+ Unfortunatelly the JCA specification is not really helpful here. But we can use a relatively 
+ simple trick and map our ActivationConfigProperties to system properties.
+ Every application server has means for configuring system properties mostly via the
+ administration interface.
+ 
+ If you wish to use this feature, then you need to provide an additional @ActivationConfigProperty 
+ called *systemPropertyPrefix*. If you set this property, then the Connector will check if
+ there any ActivationConfigProperty is available in the system properties and use it if so.
+ 
+ The name of the system property is *\<prefix\>.\<property\>*.
+ 
+ Our previous example might also set following system properties:
+ 
+ | System property name             | Value
+ |----------------------------------|-------
+ | my-kafka.bootstrapServersConfig  | localhost:9092
+ 
+ And rewrite our MDB to:
+
+```java
+@MessageDriven(activationConfig = {
+    @ActivationConfigProperty(propertyName = "clientId", propertyValue = "testClient"),
+    @ActivationConfigProperty(propertyName = "groupIdConfig", propertyValue = "testGroup"),
+    @ActivationConfigProperty(propertyName = "topics", propertyValue = "test,test2"),
+    @ActivationConfigProperty(propertyName = "autoCommitInterval", propertyValue = "100"),    
+    @ActivationConfigProperty(propertyName = "retryBackoff", propertyValue = "1000"),    
+    @ActivationConfigProperty(propertyName = "keyDeserializer", propertyValue = "org.apache.kafka.common.serialization.StringDeserializer"),    
+    @ActivationConfigProperty(propertyName = "valueDeserializer", propertyValue = "org.apache.kafka.common.serialization.StringDeserializer"),    
+    @ActivationConfigProperty(propertyName = "pollInterval", propertyValue = "3000"),    
+    @ActivationConfigProperty(propertyName = "systemPropertyPrefix", propertyValue = "my-kafka"),    
+})
+public class KafkaMDB implements KafkaListener {
+}
+``` 
+
+Now the URL of our Kafka Cluster can be configured via Application Server administration console.
+Just don't forget to reload your application after you have changed the properties.
+
 ## Outbound messages sending
 It is also possible to send messages to the Kafka topic using a defined connection factory. 
 A full example of this is shown below;


### PR DESCRIPTION
Having bootstrapServer hardcoded in the software seems impractical for real-life deployments.
This little trick provides optional override mechanism for ActivationConfigProperties via system properties which can be in turn managed via application server administration console.

Best regards,
Ladi