### PR TITLE
Add support for complexe additional properties in Kafka connector

### DIFF
--- a/Kafka/KafkaJCAAPI/src/test/java/fish/payara/cloud/connectors/kafka/tools/AdditionalPropertiesParserTest.java
+++ b/Kafka/KafkaJCAAPI/src/test/java/fish/payara/cloud/connectors/kafka/tools/AdditionalPropertiesParserTest.java
@@ -18,6 +18,11 @@ public class AdditionalPropertiesParserTest {
                 {"A=aValue , B=bValue", properties(new String[]{"A", "B"}, new String[]{"aValue","bValue"})},
                 {"A=aValue , B=b1Value , b2Value", properties(new String[]{"A", "B"}, new String[]{"aValue","b1Value,b2Value"})},
                 {"A=aValue , B=b1Value , B=b2Value", properties(new String[]{"A", "B"}, new String[]{"aValue","b1Value,b2Value"})},
+                {"A='aValue , b1Value' , B=b2Value", properties(new String[]{"A", "B"}, new String[]{"aValue , b1Value","b2Value"})},
+                {"A='aValue B=b1Value' , B=b2Value", properties(new String[]{"A", "B"}, new String[]{"aValue B=b1Value","b2Value"})},
+                {"A='aValue , B=b1Value' , B=b2Value", properties(new String[]{"A", "B"}, new String[]{"aValue , B=b1Value","b2Value"})},
+                {"A='aValue , '' B=b1Value' , B=b2Value", properties(new String[]{"A", "B"}, new String[]{"aValue , ' B=b1Value","b2Value"})},
+                {"A='''aValue , B=b1Value''' , B=b2Value", properties(new String[]{"A", "B"}, new String[]{"'aValue , B=b1Value'","b2Value"})},
         };
     }
 


### PR DESCRIPTION
The additional properties annotation for the setup of the Kafka connection accepts single quotes to wrap parts of the value, which contain the list and/or key value separator itself. This allows more complexe values, for example:
security.protocol=SASL_SSL,sasl.mechanism=PLAIN,sasl.jaas.config='org.apache.kafka.common.security.plain.PlainLoginModule required username="foo" password="bar";'

If a value should contain single quotes, the whole values has to be wrapped in single quotes and the quotes inside the value must be duplicated.