### PR TITLE
Kafka connector supports initialPollDelay

### DIFF
--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaAsynchWorker.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaAsynchWorker.java
@@ -47,6 +47,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -75,6 +76,10 @@ public class KafkaAsynchWorker implements KafkaWorker {
 
     private final List<Method> onRecordMethods = new ArrayList<>();
     private final List<Method> onRecordsMethods = new ArrayList<>();
+
+    private final long startTime = new Date().getTime();
+    private AtomicBoolean started = new AtomicBoolean();
+
 
     public KafkaAsynchWorker(EndpointKey key, WorkManager wm) {
         // new work for the specified key
@@ -118,7 +123,13 @@ public class KafkaAsynchWorker implements KafkaWorker {
         return stopped.get();
     }
 
-    
+    private void checkStart(){
+        if (new Date().getTime()>key.getSpec().getInitialPollDelay()+startTime) {
+            started.set(true);
+        }else {
+//            LOGGER.log(Level.WARNING, "waiting for a bit before processing start" + new Date(startTime) +  " now: " + new Date());
+        }
+    }
     
     @Override
     public void release() {
@@ -127,24 +138,28 @@ public class KafkaAsynchWorker implements KafkaWorker {
 
     @Override
     public void run() {
-        ConsumerRecords<Object, Object> records = consumer.poll(Duration.of(key.getSpec().getPollInterval(), ChronoUnit.MILLIS));
-        if (!records.isEmpty()) {
-            try {
-                // ok we got something
-                // schedule on the Work Manager Again
-                wm.scheduleWork(new RecordsProcessor(records));
-            } catch (WorkException ex) {
-                Logger.getLogger(KafkaAsynchWorker.class.getName()).log(Level.SEVERE, null, ex);
-            }
-            
-            if (key.getSpec().getCommitEachPoll()) {
-                consumer.commitSync();
-            }
-        }
+        if (!started.get()) {
+            checkStart();
+        }else{
+            ConsumerRecords<Object, Object> records = consumer.poll(Duration.of(key.getSpec().getPollInterval(), ChronoUnit.MILLIS));
+            if (!records.isEmpty()) {
+                try {
+                    // ok we got something
+                    // schedule on the Work Manager Again
+                    wm.scheduleWork(new RecordsProcessor(records));
+                } catch (WorkException ex) {
+                    Logger.getLogger(KafkaAsynchWorker.class.getName()).log(Level.SEVERE, null, ex);
+                }
 
-        // consume records
-        if (stopped.get()) {
-            consumer.close();
+                if (key.getSpec().getCommitEachPoll()) {
+                    consumer.commitSync();
+                }
+            }
+
+            // consume records
+            if (stopped.get()) {
+                consumer.close();
+            }
         }
     }
 

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaAsynchWorker.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaAsynchWorker.java
@@ -124,10 +124,16 @@ public class KafkaAsynchWorker implements KafkaWorker {
     }
 
     private void checkStart(){
-        if (new Date().getTime()>key.getSpec().getInitialPollDelay()+startTime) {
+        long now = System.currentTimeMillis();
+        if (now >key.getSpec().getInitialPollDelay()+startTime) {
             started.set(true);
         }else {
-//            LOGGER.log(Level.WARNING, "waiting for a bit before processing start" + new Date(startTime) +  " now: " + new Date());
+            try {
+                Thread.sleep(key.getSpec().getInitialPollDelay() - (now - startTime));
+                started.set(true);
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.WARNING, "Interrupt during sleep while waiting for initial poll delay");
+            }
         }
     }
     

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaSynchWorker.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaSynchWorker.java
@@ -47,6 +47,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -102,7 +103,11 @@ public class KafkaSynchWorker implements KafkaWorker {
 
     @Override
     public void run() {
-        
+        try {
+            Thread.sleep(key.getSpec().getInitialPollDelay());
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.WARNING, "Interrupt Exception in wait for start");
+        }
         try {
             // create the consumer
             consumer = new KafkaConsumer(key.getSpec().getConsumerProperties());


### PR DESCRIPTION
Not sure if this is something you would like to see included, we ran into issues with the message driven beans starting to be produced before the application could deal with them properly (eventually leading to locked threads and no more messages being created). The solution was to allow the kafka-connecter to also honor the initialPollDelay activation spec, setting a delay gives the application time to start up before it starts getting beans delivered. 

