### PR TITLE
feature/add-profile-name-option-aws-sqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 target/
+
+# IntelliJ
+.idea/
+*.iml

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
@@ -55,25 +55,27 @@ import javax.resource.spi.ManagedConnectionFactory;
 import javax.security.auth.Subject;
 
 /**
- *
  * @author Steve Millidge (Payara Foundation)
  */
-@ConnectionDefinition( connection = AmazonSQSConnection.class,
+@ConnectionDefinition(connection = AmazonSQSConnection.class,
         connectionFactory = AmazonSQSConnectionFactory.class,
         connectionFactoryImpl = AmazonSQSConnectionFactoryImpl.class,
         connectionImpl = AmazonSQSConnectionImpl.class
 )
 public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFactory, Serializable {
-    
+
     @ConfigProperty(description = "AWS Secret Key", type = String.class)
     private String awsSecretKey;
-    
-    @ConfigProperty(description = "AWS Access Key", type=String.class)
+
+    @ConfigProperty(description = "AWS Access Key", type = String.class)
     private String awsAccessKeyId;
-    
-    @ConfigProperty(description = "Region hosting the queue", type=String.class)
+
+    @ConfigProperty(description = "Region hosting the queue", type = String.class)
     private String region;
-    
+
+    @ConfigProperty(description = "AWS Profile Name", type = String.class)
+    private String profileName;
+
     private PrintWriter logger;
 
     public String getAwsSecretKey() {
@@ -100,11 +102,19 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
         this.region = region;
     }
 
+    public String getProfileName() {
+        return profileName;
+    }
+
+    public void setProfileName(String profileName) {
+        this.profileName = profileName;
+    }
+
     public AmazonSQSManagedConnectionFactory() {
     }
-    
-    
-    
+
+
+
     @Override
     public Object createConnectionFactory(ConnectionManager cxManager) throws ResourceException {
         return new AmazonSQSConnectionFactoryImpl(cxManager, this);
@@ -142,6 +152,7 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
         hash = 97 * hash + Objects.hashCode(this.awsSecretKey);
         hash = 97 * hash + Objects.hashCode(this.awsAccessKeyId);
         hash = 97 * hash + Objects.hashCode(this.region);
+        hash = 97 * hash + Objects.hashCode(this.profileName);
         return hash;
     }
 
@@ -166,9 +177,12 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
         if (!Objects.equals(this.region, other.region)) {
             return false;
         }
+        if (!Objects.equals(this.profileName, other.profileName)) {
+            return false;
+        }
         return true;
     }
-    
-    
-    
+
+
+
 }

--- a/AmazonSQS/README.md
+++ b/AmazonSQS/README.md
@@ -36,8 +36,9 @@ Valid properties are below. On Payara all properties can be replaced via System 
 
 |Config Property Name | Type | Default | Notes
 |---------------------|------|---------|------
-|awsAccessKeyId | String | None | Must be set to the access key of your AWS account
-|awsSecretKey | String | None | Must be set to the secret key of your AWS account
+|awsAccessKeyId | String | None | Must be set to the access key of your AWS account. Ignored if profileName is present
+|awsSecretKey | String | None | Must be set to the secret key of your AWS account. Ignored if profileName is present
+|profileName | String | None | AWS Profile Name as configured in ~/.aws directory. 
 |queueURL | String | None | Must be set to the URL for an SQS queue
 |region | String | None | Must be set to the AWS region name of your queue
 |maxMessages | Integer | 10 | The maximum number of messages to download on a poll
@@ -48,7 +49,7 @@ Valid properties are below. On Payara all properties can be replaced via System 
 
 Your MDB should contain one method annotated with `@OnSQSMessage` and that method should take a single parameter of type `com.amazonaws.services.sqs.model.Message`
 
-A full skeleton MDB is shown below
+A full skeleton MDB using Access and Secret keys shown below
 ```java
 @MessageDriven(activationConfig = {
     @ActivationConfigProperty(propertyName = "awsAccessKeyId", propertyValue = "${ENV=accessKey}"),
@@ -65,7 +66,22 @@ public class ReceiveSQSMessage implements AmazonSQSListener {
     }
 }
 ```
+Using Profile Name
+```java
+@MessageDriven(activationConfig = {
+    @ActivationConfigProperty(propertyName = "profileName", propertyValue = "${ENV=profileName}"),
+    @ActivationConfigProperty(propertyName = "queueURL", propertyValue = "${ENV=queueURL}"),   
+    @ActivationConfigProperty(propertyName = "pollInterval", propertyValue = "1"),    
+    @ActivationConfigProperty(propertyName = "region", propertyValue = "eu-west-2")    
+})
+public class ReceiveSQSMessage implements AmazonSQSListener {
 
+    @OnSQSMessage
+    public void receiveMessage(Message message) {
+        System.out.println("Got message " + message.getBody());
+    }
+}
+```
 ## Outbound messages sending
 It is also possible to send messages to the queue using a defined connection factory. 
 A full example of this is shown below;
@@ -90,7 +106,11 @@ An example annotation defined connection factory is shown below;
                 "awsSecretKey=${ENV=secretKey}",
                 "region=eu-west-2"})
 ```
-
+Profile Name properties configuration
+```java
+  properties = {"profileName=${ENV=profileName}"
+                "region=eu-west-2"})
+```
 This connection factory can then be injected into any JavaEE component;
 ```java
     @Resource(lookup="java:comp/env/SQSConnectionFactory")


### PR DESCRIPTION
Adding Option for Profile Name as configured in ~/.aws directory

Use profileName for credential configuration of client. Takes priority over access/secret key
Replaced null checks with isNullOrEmpty (used from AWS SDK package)
Updated README to document the use of profileName