### PR TITLE
use break instead of return

### DIFF
--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaSynchWorker.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/inbound/KafkaSynchWorker.java
@@ -131,7 +131,7 @@ public class KafkaSynchWorker implements KafkaWorker {
                         Logger.getLogger(KafkaSynchWorker.class.getName()).log(Level.SEVERE, null, ex);
                     }
                     if (!recordsAnnt.matchOtherMethods()) {
-                        return;
+                        break;
                     }
                 }
                 


### PR DESCRIPTION
Rationale: return would end the thread.