### PR TITLE
avoid null producer on createManagedConnection

### DIFF
--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/outbound/KafkaManagedConnectionFactory.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/outbound/KafkaManagedConnectionFactory.java
@@ -364,6 +364,9 @@ public class KafkaManagedConnectionFactory implements ManagedConnectionFactory, 
                 additionalPropertiesParser == null
                         ? producerProperties
                         : AdditionalPropertiesParser.merge(producerProperties,  additionalPropertiesParser.parse());
+        if (producer == null) {
+            producer = new KafkaProducer(properties);
+        }
         return new KafkaManagedConnection(producer);
     }
 


### PR DESCRIPTION
This was observed on Weblogic 12c.