### PR TITLE
FISH-7015 Resolve Javadoc Errors

### DIFF
--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/api/OnRecord.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/api/OnRecord.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -60,7 +60,7 @@ public @interface OnRecord {
      * If topics is an empty array all topics will trigger the callback
      * Otherwise this method will only match records sent on the topics specified.
      * 
-     * @return 
+     * @return A String list of topics from the annotation
     */
     @Nonbinding String[] topics() default {};
     
@@ -69,7 +69,7 @@ public @interface OnRecord {
      * if they also match the topic as well as this annotated method
      * If set to false (the default) other methods will not be tested to see if they
      * have matching annotations.
-     * @return 
+     * @return The value of matchOtherMethods from the annotation
      */
     @Nonbinding boolean matchOtherMethods() default false;
 }

--- a/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/api/OnRecords.java
+++ b/Kafka/KafkaJCAAPI/src/main/java/fish/payara/cloud/connectors/kafka/api/OnRecords.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -63,7 +63,7 @@ public @interface OnRecords {
      * if they also match the topic as well as this annotated method.
      * If set to false (the default) other methods will not be tested to see if they
      * have matching annotations.
-     * @return 
+     * @return The value of matchOtherMethods from the annotation
      */
     @Nonbinding boolean matchOtherMethods() default false;
 }

--- a/MQTT/MQTTJCAAPI/src/main/java/fish/payara/cloud/connectors/mqtt/api/MQTTConnection.java
+++ b/MQTT/MQTTJCAAPI/src/main/java/fish/payara/cloud/connectors/mqtt/api/MQTTConnection.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -54,15 +54,15 @@ public interface MQTTConnection extends AutoCloseable {
       * @param payload Byte array to use as message payload
      * @param qos Quality of Service valid values are 0,1,2
      * @param retained Whether or not this message should be retained by the server.
-     * @throws javax.resource.ResourceException
+     * @throws jakarta.resource.ResourceException When unable to send the message to the MQTT Server
      */
     public void publish(String topic, byte payload[], int qos, boolean retained) throws ResourceException;
     
     /**
      * Publish a message on the MQTT topic
-     * @param topic
-     * @param message
-     * @throws ResourceException
+     * @param topic Name of the topic to publish the message
+     * @param message The MQTT message to be published
+     * @throws jakarta.resource.ResourceException When unable to send the message to the MQTT Server
      */
     public void publish (String topic, MqttMessage message) throws ResourceException;
     

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) [2023] Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at glassfish/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    The Payara Foundation designates this particular file as subject to the "Classpath"
+    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.cloud.connectors</groupId>
@@ -96,7 +135,7 @@
                             <splitindex>true</splitindex>
                             <doctitle>Cloud Connectors</doctitle>
                             <links>
-                                <link>https://docs.oracle.com/javaee/${javaee.version}/api/</link>
+                                <link>https://jakarta.ee/specifications/platform/10/apidocs/</link>
                             </links>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Currently Cloud Connectors master can't be pushed to maven central due to incomplete javadoc, this resolves any issues flagged when running `mvn javadoc:javadoc`