### PR TITLE
Remove JDK 8 From Workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        java: [8, 11, 17]
+        java: [11, 17]
       fail-fast: false
       max-parallel: 2          
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ steps:
     mavenPomFile: 'pom.xml'
     mavenOptions: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.8'
+    jdkVersionOption: '11'
     jdkArchitectureOption: 'x64'
     publishJUnitResults: false
     testResultsFiles: '**/surefire-reports/TEST-*.xml'


### PR DESCRIPTION
Removes JDK 8 from the workflow. Master is based on Jakarta EE 10 with maven enforcer set to JDK 11 minimum so we shouldn't be testing against JDK 8