### PR TITLE
FISH-7866 AWS SDK Security Token Service (STS) support (Payara5)

### DIFF
--- a/AmazonSQS/AmazonSQSExample/pom.xml
+++ b/AmazonSQS/AmazonSQSExample/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.12.286</version>
+            <version>1.12.661</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/AmazonSQS/AmazonSQSJCAAPI/pom.xml
+++ b/AmazonSQS/AmazonSQSJCAAPI/pom.xml
@@ -27,5 +27,9 @@
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/AmazonSQS/AmazonSQSJCAAPI/pom.xml
+++ b/AmazonSQS/AmazonSQSJCAAPI/pom.xml
@@ -17,19 +17,21 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-bom</artifactId>
-            <version>1.12.286</version>
+            <version>1.12.661</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.12.286</version>
+            <version>1.12.661</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sts</artifactId>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>1.12.661</version>
+            <type>jar</type>
         </dependency>
     </dependencies>
 </project>

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/AmazonSQSActivationSpec.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/AmazonSQSActivationSpec.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -45,12 +45,20 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.util.StringUtils;
 import fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSListener;
+import fish.payara.cloud.connectors.amazonsqs.api.outbound.STSCredentialsProvider;
 
 import javax.resource.ResourceException;
 import javax.resource.spi.Activation;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.InvalidPropertyException;
 import javax.resource.spi.ResourceAdapter;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * Activation Specification for Amazon SQS
@@ -73,7 +81,9 @@ public class AmazonSQSActivationSpec implements ActivationSpec, AWSCredentialsPr
     private String messageAttributeNames = "All";
     private String attributeNames = "All";
     private String profileName;
-    
+    private String roleArn;
+    private String roleSessionName;
+
     @Override
     public void validate() throws InvalidPropertyException {
         if (StringUtils.isNullOrEmpty(region)) {
@@ -182,31 +192,33 @@ public class AmazonSQSActivationSpec implements ActivationSpec, AWSCredentialsPr
     public void setProfileName(String profileName) {
         this.profileName = profileName;
     }
-    
-    @Override
-    public AWSCredentials getCredentials() {
 
-        // Return Credentials based on what is present, profileName taking priority.
-        if (StringUtils.isNullOrEmpty(getProfileName())) {
-            
-            if (!StringUtils.isNullOrEmpty(awsAccessKeyId) && !StringUtils.isNullOrEmpty(awsSecretKey)) {
-                return new AWSCredentials() {
-                    @Override
-                    public String getAWSAccessKeyId() {
-                        return awsAccessKeyId;
-                    }
-                    
-                    @Override
-                    public String getAWSSecretKey() {
-                        return awsSecretKey;
-                    }
-                };
-            } else {
-                return DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
-            }
-            
+    public String getRoleArn() {
+        return roleArn;
+    }
+
+    public void setRoleArn(String roleArn) {
+        this.roleArn = roleArn;
+    }
+
+    public String getRoleSessionName() {
+        return roleSessionName;
+    }
+
+    public void setRoleSessionName(String roleSessionName) {
+        this.roleSessionName = roleSessionName;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        if (StringUtils.isNotBlank(getRoleArn())) {
+            return STSCredentialsProvider.create(getRoleArn(), getRoleSessionName(), Region.of(getRegion())).resolveCredentials();
+        } else if (StringUtils.isNotBlank(getProfileName())) {
+            return ProfileCredentialsProvider.builder().profileName(getProfileName()).build().resolveCredentials();
+        } else if (StringUtils.isNotBlank(getAwsAccessKeyId()) && StringUtils.isNotBlank(getAwsSecretKey())) {
+            return AwsBasicCredentials.create(getAwsAccessKeyId(), getAwsSecretKey());
         } else {
-            return new ProfileCredentialsProvider(getProfileName()).getCredentials();
+            return DefaultCredentialsProvider.create().resolveCredentials();
         }
     }
     

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -76,6 +76,12 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
     @ConfigProperty(description = "AWS Profile Name", type = String.class)
     private String profileName;
 
+    @ConfigProperty(description = "AWS Role ARN", type = String.class)
+    private String roleArn;
+
+    @ConfigProperty(description = "AWS Session name", type = String.class)
+    private String roleSessionName;
+
     private PrintWriter logger;
 
     public String getAwsSecretKey() {
@@ -110,10 +116,21 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
         this.profileName = profileName;
     }
 
-    public AmazonSQSManagedConnectionFactory() {
+    public String getRoleArn() {
+        return roleArn;
     }
 
+    public void setRoleArn(String roleArn) {
+        this.roleArn = roleArn;
+    }
 
+    public String getRoleSessionName() {
+        return roleSessionName;
+    }
+
+    public void setRoleSessionName(String roleSessionName) {
+        this.roleSessionName = roleSessionName;
+    }
 
     @Override
     public Object createConnectionFactory(ConnectionManager cxManager) throws ResourceException {
@@ -148,11 +165,13 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
 
     @Override
     public int hashCode() {
-        int hash = 5;
+        int hash = 7;
         hash = 97 * hash + Objects.hashCode(this.awsSecretKey);
         hash = 97 * hash + Objects.hashCode(this.awsAccessKeyId);
         hash = 97 * hash + Objects.hashCode(this.region);
         hash = 97 * hash + Objects.hashCode(this.profileName);
+        hash = 97 * hash + Objects.hashCode(this.roleArn);
+        hash = 97 * hash + Objects.hashCode(this.roleSessionName);
         return hash;
     }
 
@@ -180,7 +199,10 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
         if (!Objects.equals(this.profileName, other.profileName)) {
             return false;
         }
-        return true;
+        if (!Objects.equals(this.roleArn, other.roleArn)) {
+            return false;
+        }
+        return Objects.equals(this.roleSessionName, other.roleSessionName);
     }
 
 

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/STSCredentialsProvider.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/STSCredentialsProvider.java
@@ -1,0 +1,138 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.amazonsqs.api.outbound;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+/**
+ * AWS STS Credentials Provider with caching and thread safety.
+ * 
+ * This class provides AWS credentials by assuming a role using the AWS Security Token Service (STS).
+ * It caches the credentials and ensures thread safety using locks.
+ * 
+ * @author Gaurav Gupta
+ */
+public class STSCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(STSCredentialsProvider.class.getName());
+    private static final Duration EXPIRATION_THRESHOLD = Duration.ofMinutes(5);
+    private final String roleArn;
+    private final String roleSessionName;
+    private final Region region;
+    private volatile AwsSessionCredentials cachedCredentials;
+    private volatile Instant expirationTime;
+    private final Lock lock = new ReentrantLock();
+    private static final Map<String, STSCredentialsProvider> providerInstances = new HashMap<>();
+   
+    /**
+     * Returns a singleton instance of STSCredentialsProvider for a unique session name.
+     * 
+     * @param roleArn The ARN of the role to assume.
+     * @param roleSessionName The name of the role session.
+     * @param region The AWS region.
+     * @return The STSCredentialsProvider instance.
+     */
+    public static STSCredentialsProvider create(String roleArn, String roleSessionName, Region region) {
+        String uniqueSessionKey = roleSessionName + "@" + region.id();
+        return providerInstances.computeIfAbsent(uniqueSessionKey, key -> new STSCredentialsProvider(roleArn, roleSessionName, region));
+    }
+
+    private STSCredentialsProvider(String roleArn, String roleSessionName, Region region) {
+        this.roleArn = roleArn;
+        this.roleSessionName = roleSessionName;
+        this.region = region;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        if (cachedCredentials != null && !isCredentialsExpired()) {
+            LOGGER.fine("Reusing cached AWS session credentials");
+            return cachedCredentials;
+        } else {
+            lock.lock();
+            try {
+                if (cachedCredentials != null && !isCredentialsExpired()) {
+                    LOGGER.fine("Reusing cached AWS session credentials after lock");
+                    return cachedCredentials;
+                }
+                LOGGER.fine("Cached AWS session credentials expired or not present");
+
+                StsClient stsClient = StsClient.builder().region(region).build();
+                AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
+                        .roleArn(roleArn)
+                        .roleSessionName(roleSessionName)
+                        .build();
+
+                AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(assumeRoleRequest);
+                Credentials stsCredentials = assumeRoleResponse.credentials();
+                cachedCredentials = AwsSessionCredentials.create(
+                        stsCredentials.accessKeyId(),
+                        stsCredentials.secretAccessKey(),
+                        stsCredentials.sessionToken()
+                );
+                expirationTime = stsCredentials.expiration();
+                LOGGER.log(Level.FINE, "Obtained new AWS session credentials - Session Token: {0}, Expiration Time: {1}", new Object[]{stsCredentials.sessionToken(), stsCredentials.expiration()});
+                return cachedCredentials;
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    private boolean isCredentialsExpired() {
+        // Check if the credentials are expired or about to expire
+        return expirationTime == null || Instant.now().isAfter(expirationTime.minus(EXPIRATION_THRESHOLD));
+    }
+}

--- a/AmazonSQS/AmazonSQSRAR/pom.xml
+++ b/AmazonSQS/AmazonSQSRAR/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fish.payara.cloud.connectors</groupId>
@@ -14,16 +16,25 @@
     <name>Amazon SQS JCA Adapter RAR</name>
     <description>RAR for the Amazon SQS JCA Adapter</description>
     <url>http://www.payara.fish</url>
+    <properties>
+        <awssdk.version>2.23.3</awssdk.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>fish.payara.cloud.connectors.amazonsqs</groupId>
             <artifactId>amazon-sqs-jca-api</artifactId>
             <version>${project.version}</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.12.286</version>
+            <version>1.12.661</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>1.12.661</version>
             <type>jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR adds support for AWS STS auth in Payara Cloud Connector - AWS SQS

To enhance security and provide temporary, limited-access credentials for your Java application using Payara Cloud Connector for AWS SQS, integrate with AWS Security Token Service (STS) through Identity and Access Management (IAM). Follow these steps to set up STS integration:

### Creating IAM Role

#### Steps:

1. **Open the IAM Console**
    - Navigate to the AWS Management Console and open the IAM console.

2. **Create an IAM Role**
    - In the left navigation pane, choose "**Roles**".
    - Choose "**Create role**".
    - Select "**AWS account**".
    - Enter the AWS account ID (skip if working within the same AWS account).
    - Choose "**Next**".

3. **Add permissions**
    - Search for **AmazonSQSFullAccess** policy and attach it.
    - Choose "**Next**".

4. **Role details**
    - Give the role a Name (e.g., "PayaraSQSRole").
    - Add a meaningful description.
    - Choose "**Create role**".

5. **Retrieve User ARN**

    -  Navigate back to the IAM console.
    - In the left navigation pane, choose "**Users**."
    - Select the IAM user (e.g., "MY-USER").
    - Copy the User ARN from the user's summary page (e.g., "arn:aws:iam::xxxxxxxxx:user/MY-USER").

6. **Retrieve Role ARN**
    - After creating the role, copy the Role ARN from the summary page.
    
7. **Update Trust Relationship**
    - To resolve potential authorization issues related to role assumption, ensure that the Trust Relationship in the IAM role is configured correctly. Update the Trust Relationship to explicitly allow the user to assume the role. Below is an example Trust Relationship JSON:
````
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "AWS": "<YOUR-IAM-USER-ARN-HERE>"
            },
            "Action": "sts:AssumeRole",
            "Condition": {}
        }
    ]
}
````

Make sure to replace the values with your specific IAM user ARN and role ARN.

8. **Set Role Session Name**
    - For the `roleSessionName`, choose a logical name for your session (e.g., "PayaraSQSSession").
    
    
### Conclusion

It's crucial to establish a link between the IAM user's ARN and the IAM role's Trust Relationship by configuring the Trust Relationship with the user's ARN. This linkage ensures that the IAM user has the necessary permissions to assume the role. Additionally, for seamless integration, configure the `roleArn` and `roleSessionName` in the Payara Cloud Connector AWS SQS:

**roleArn**: The ARN of the IAM role you've just created.
**roleSessionName**: A logical name for your session (e.g., "PayaraSQSSession").

These values play a crucial role in the configuration of Payara Cloud Connector AWS SQS, enabling your Java application to establish the necessary connections securely.


## Sending Messages

Sending messages to Amazon SQS can be done via the JCA and an Amazon-specific API. Define a resource using the JCA API and a connection factory. The following Java code provides an example:

````
@ConnectionFactoryDefinition ( 
  name = "java:app/amazonsqs/factory",
  interfaceName = "fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSConnectionFactory",
  resourceAdapter = "amazon-sqs-rar-0.8.0",
  properties = {"awsAccessKeyId=<accessKeyID>", "awsSecretKey=<secretKey>",
  "roleArn=arn:aws:iam::xxxxxxxxx:role/PayaraSQSRole", "roleSessionName=PayaraSQSSession", "region=eu-west-2"}
)
````

With this definition, you can send messages using the following example code:
````
@Singleton
@Startup
public class SendSQSMessage {
 
 @Resource(lookup = "java:app/amazonsqs/factory")
 private AmazonSQSConnectionFactory factory;
 
 @PostConstruct
 public void init() {
    try (AmazonSQSConnection connection = factory.createConnection()) {
        connection.sendMessage(new SendMessageRequest("<queueURL>", "Hello World"));
    }
    catch (Exception ex) {
    }
 }  
}

````

## Receiving Messages
Messages can be received from Amazon SQS by creating an MDB (Message Driven Bean) that implements the `fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSListener` marker interface. Below is an example:

````
@MessageDriven(activationConfig = {
 @ActivationConfigProperty(propertyName = "awsAccessKeyId", propertyValue = "someKey"),
 @ActivationConfigProperty(propertyName = "awsSecretKey", propertyValue = "someSecretKey"),
 @ActivationConfigProperty(propertyName = "queueURL", propertyValue = "someQueueURL"), 
 @ActivationConfigProperty(propertyName = "pollInterval", propertyValue = "1"), 
 @ActivationConfigProperty(propertyName = "roleArn", propertyValue = "arn:aws:iam::xxxxxxxxx:role/PayaraSQSRole") , 
 @ActivationConfigProperty(propertyName = "roleSessionName", propertyValue = "PayaraSQSSession") , 
 @ActivationConfigProperty(propertyName = "region", propertyValue = "eu-west-2") 
})
public class ReceiveSQSMessage implements AmazonSQSListener {

 @OnSQSMessage
 public void receiveMessage(Message message) {
     // Handle message
 }
}

````

## Documentation
https://github.com/payara/Payara-Documentation/pull/394 (Payara6)
https://github.com/payara/Payara-Documentation/pull/393 (Payara5)