### PR TITLE
FISH-8109 Extending Amazon SQS Connector with methods from AWS SqsClient class

### DIFF
--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/AmazonSQSConnection.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/AmazonSQSConnection.java
@@ -39,22 +39,150 @@
  */
 package fish.payara.cloud.connectors.amazonsqs.api;
 
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.ResponseMetadata;
+import com.amazonaws.services.sqs.model.AddPermissionRequest;
+import com.amazonaws.services.sqs.model.AddPermissionResult;
+import com.amazonaws.services.sqs.model.CancelMessageMoveTaskRequest;
+import com.amazonaws.services.sqs.model.CancelMessageMoveTaskResult;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequest;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchResult;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityResult;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.CreateQueueResult;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchResult;
+import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageResult;
+import com.amazonaws.services.sqs.model.DeleteQueueRequest;
+import com.amazonaws.services.sqs.model.DeleteQueueResult;
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
+import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
+import com.amazonaws.services.sqs.model.GetQueueUrlResult;
+import com.amazonaws.services.sqs.model.ListDeadLetterSourceQueuesRequest;
+import com.amazonaws.services.sqs.model.ListDeadLetterSourceQueuesResult;
+import com.amazonaws.services.sqs.model.ListMessageMoveTasksRequest;
+import com.amazonaws.services.sqs.model.ListMessageMoveTasksResult;
+import com.amazonaws.services.sqs.model.ListQueueTagsRequest;
+import com.amazonaws.services.sqs.model.ListQueueTagsResult;
+import com.amazonaws.services.sqs.model.ListQueuesRequest;
+import com.amazonaws.services.sqs.model.ListQueuesResult;
+import com.amazonaws.services.sqs.model.PurgeQueueRequest;
+import com.amazonaws.services.sqs.model.PurgeQueueResult;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.RemovePermissionRequest;
+import com.amazonaws.services.sqs.model.RemovePermissionResult;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageBatchResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
+import com.amazonaws.services.sqs.model.SetQueueAttributesRequest;
+import com.amazonaws.services.sqs.model.SetQueueAttributesResult;
+import com.amazonaws.services.sqs.model.StartMessageMoveTaskRequest;
+import com.amazonaws.services.sqs.model.StartMessageMoveTaskResult;
+import com.amazonaws.services.sqs.model.TagQueueRequest;
+import com.amazonaws.services.sqs.model.TagQueueResult;
+import com.amazonaws.services.sqs.model.UntagQueueRequest;
+import com.amazonaws.services.sqs.model.UntagQueueResult;
 import java.util.List;
+import java.util.Map;
 
 /**
  *
  * @author Steve Millidge (Payara Foundation)
  */
 public interface AmazonSQSConnection extends AutoCloseable {
-    
-    public SendMessageResult sendMessage(SendMessageRequest request);
-    public SendMessageResult sendMessage(String queueURL, String messageBody);
-    public SendMessageBatchResult sendMessageBatch(String queueURL, List<SendMessageBatchRequestEntry> entries);
-    public SendMessageBatchResult sendMessageBatch(SendMessageBatchRequest batch);
-    
+
+    SendMessageResult sendMessage(SendMessageRequest request);
+
+    SendMessageResult sendMessage(String queueURL, String messageBody);
+
+    SendMessageBatchResult sendMessageBatch(String queueURL, List<SendMessageBatchRequestEntry> entries);
+
+    SendMessageBatchResult sendMessageBatch(SendMessageBatchRequest batch);
+
+    ReceiveMessageResult receiveMessage(ReceiveMessageRequest receiveMessageRequest);
+
+    ReceiveMessageResult receiveMessage(String queueUrl);
+
+    GetQueueAttributesResult getQueueAttributes(GetQueueAttributesRequest getQueueAttributesRequest);
+
+    GetQueueAttributesResult getQueueAttributes(String queueUrl, List<String> attributeNames);
+
+    SetQueueAttributesResult setQueueAttributes(SetQueueAttributesRequest setQueueAttributesRequest);
+
+    SetQueueAttributesResult setQueueAttributes(String queueUrl, Map<String, String> attributes);
+
+    CreateQueueResult createQueue(CreateQueueRequest createQueueRequest);
+
+    CreateQueueResult createQueue(String queueName);
+
+    DeleteMessageResult deleteMessage(DeleteMessageRequest deleteMessageRequest);
+
+    DeleteMessageResult deleteMessage(String queueUrl, String receiptHandle);
+
+    DeleteMessageBatchResult deleteMessageBatch(DeleteMessageBatchRequest deleteMessageBatchRequest);
+
+    DeleteMessageBatchResult deleteMessageBatch(String queueUrl, List<DeleteMessageBatchRequestEntry> entries);
+
+    DeleteQueueResult deleteQueue(DeleteQueueRequest deleteQueueRequest);
+
+    DeleteQueueResult deleteQueue(String queueUrl);
+
+    GetQueueUrlResult getQueueUrl(GetQueueUrlRequest getQueueUrlRequest);
+
+    GetQueueUrlResult getQueueUrl(String queueName);
+
+    ListQueueTagsResult listQueueTags(ListQueueTagsRequest listQueueTagsRequest);
+
+    ListQueueTagsResult listQueueTags(String queueUrl);
+
+    ListQueuesResult listQueues();
+
+    ListQueuesResult listQueues(ListQueuesRequest listQueuesRequest);
+
+    ListQueuesResult listQueues(String queueNamePrefix);
+
+    PurgeQueueResult purgeQueue(PurgeQueueRequest purgeQueueRequest);
+
+    TagQueueResult tagQueue(TagQueueRequest tagQueueRequest);
+
+    TagQueueResult tagQueue(String queueUrl, Map<String, String> tags);
+
+    UntagQueueResult untagQueue(UntagQueueRequest untagQueueRequest);
+
+    UntagQueueResult untagQueue(String queueUrl, List<String> tagKeys);
+
+    AddPermissionResult addPermission(AddPermissionRequest addPermissionRequest);
+
+    AddPermissionResult addPermission(String queueUrl, String label, List<String> awsAccountIds, List<String> actions);
+
+    RemovePermissionResult removePermission(RemovePermissionRequest removePermissionRequest);
+
+    RemovePermissionResult removePermission(String queueUrl, String label);
+
+    ListMessageMoveTasksResult listMessageMoveTasks(ListMessageMoveTasksRequest listMessageMoveTasksRequest);
+
+    StartMessageMoveTaskResult startMessageMoveTask(StartMessageMoveTaskRequest startMessageMoveTaskRequest);
+
+    CancelMessageMoveTaskResult cancelMessageMoveTask(CancelMessageMoveTaskRequest cancelMessageMoveTaskRequest);
+
+    ChangeMessageVisibilityResult changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest);
+
+    ChangeMessageVisibilityResult changeMessageVisibility(String queueUrl, String receiptHandle, Integer visibilityTimeout);
+
+    ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(ChangeMessageVisibilityBatchRequest changeMessageVisibilityBatchRequest);
+
+    ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(String queueUrl, List<ChangeMessageVisibilityBatchRequestEntry> entries);
+
+    ListDeadLetterSourceQueuesResult listDeadLetterSourceQueues(ListDeadLetterSourceQueuesRequest listDeadLetterSourceQueuesRequest);
+
+    ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest amazonWebServiceRequest);
+
 }

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSConnectionImpl.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSConnectionImpl.java
@@ -39,22 +39,22 @@
  */
 package fish.payara.cloud.connectors.amazonsqs.api.outbound;
 
-import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
-import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
-import com.amazonaws.services.sqs.model.SendMessageBatchResult;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
-import com.amazonaws.services.sqs.model.SendMessageResult;
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.ResponseMetadata;
+import com.amazonaws.services.sqs.model.*;
 import fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSConnection;
+
 import java.util.List;
+import java.util.Map;
 
 /**
  *
  * @author Steve Millidge (Payara Foundation)
  */
-class AmazonSQSConnectionImpl  implements AmazonSQSConnection {
-    
+class AmazonSQSConnectionImpl implements AmazonSQSConnection {
+
     private AmazonSQSManagedConnection underlyingConnection;
-    
+
     AmazonSQSConnectionImpl(AmazonSQSManagedConnection realConn) {
         underlyingConnection = realConn;
     }
@@ -87,5 +87,201 @@ class AmazonSQSConnectionImpl  implements AmazonSQSConnection {
     void setRealConnection(AmazonSQSManagedConnection aThis) {
         this.underlyingConnection = aThis;
     }
-    
+
+    @Override
+    public ReceiveMessageResult receiveMessage(ReceiveMessageRequest receiveMessageRequest) {
+        return underlyingConnection.receiveMessage(receiveMessageRequest);
+    }
+
+    @Override
+    public ReceiveMessageResult receiveMessage(String queueUrl) {
+        return underlyingConnection.receiveMessage(queueUrl);
+    }
+
+    @Override
+    public GetQueueAttributesResult getQueueAttributes(GetQueueAttributesRequest getQueueAttributesRequest) {
+        return underlyingConnection.getQueueAttributes(getQueueAttributesRequest);
+    }
+
+    @Override
+    public GetQueueAttributesResult getQueueAttributes(String queueUrl, List<String> attributeNames) {
+        return underlyingConnection.getQueueAttributes(queueUrl, attributeNames);
+    }
+
+    @Override
+    public SetQueueAttributesResult setQueueAttributes(SetQueueAttributesRequest setQueueAttributesRequest) {
+        return underlyingConnection.setQueueAttributes(setQueueAttributesRequest);
+    }
+
+    @Override
+    public SetQueueAttributesResult setQueueAttributes(String queueUrl, Map<String, String> attributes) {
+        return underlyingConnection.setQueueAttributes(queueUrl, attributes);
+    }
+
+    @Override
+    public CreateQueueResult createQueue(CreateQueueRequest createQueueRequest) {
+        return underlyingConnection.createQueue(createQueueRequest);
+    }
+
+    @Override
+    public CreateQueueResult createQueue(String queueName) {
+        return underlyingConnection.createQueue(queueName);
+    }
+
+    @Override
+    public DeleteMessageResult deleteMessage(DeleteMessageRequest deleteMessageRequest) {
+        return underlyingConnection.deleteMessage(deleteMessageRequest);
+    }
+
+    @Override
+    public DeleteMessageResult deleteMessage(String queueUrl, String receiptHandle) {
+        return underlyingConnection.deleteMessage(queueUrl, receiptHandle);
+    }
+
+    @Override
+    public DeleteMessageBatchResult deleteMessageBatch(DeleteMessageBatchRequest deleteMessageBatchRequest) {
+        return underlyingConnection.deleteMessageBatch(deleteMessageBatchRequest);
+    }
+
+    @Override
+    public DeleteMessageBatchResult deleteMessageBatch(String queueUrl, List<DeleteMessageBatchRequestEntry> entries) {
+        return underlyingConnection.deleteMessageBatch(queueUrl, entries);
+    }
+
+    @Override
+    public DeleteQueueResult deleteQueue(DeleteQueueRequest deleteQueueRequest) {
+        return underlyingConnection.deleteQueue(deleteQueueRequest);
+    }
+
+    @Override
+    public DeleteQueueResult deleteQueue(String queueUrl) {
+        return underlyingConnection.deleteQueue(queueUrl);
+    }
+
+    @Override
+    public GetQueueUrlResult getQueueUrl(GetQueueUrlRequest getQueueUrlRequest) {
+        return underlyingConnection.getQueueUrl(getQueueUrlRequest);
+    }
+
+    @Override
+    public GetQueueUrlResult getQueueUrl(String queueName) {
+        return underlyingConnection.getQueueUrl(queueName);
+    }
+
+    @Override
+    public ListQueueTagsResult listQueueTags(ListQueueTagsRequest listQueueTagsRequest) {
+        return underlyingConnection.listQueueTags(listQueueTagsRequest);
+    }
+
+    @Override
+    public ListQueueTagsResult listQueueTags(String queueUrl) {
+        return underlyingConnection.listQueueTags(queueUrl);
+    }
+
+    @Override
+    public ListQueuesResult listQueues() {
+        return underlyingConnection.listQueues();
+    }
+
+    @Override
+    public ListQueuesResult listQueues(ListQueuesRequest listQueuesRequest) {
+        return underlyingConnection.listQueues(listQueuesRequest);
+    }
+
+    @Override
+    public ListQueuesResult listQueues(String queueNamePrefix) {
+        return underlyingConnection.listQueues(queueNamePrefix);
+    }
+
+    @Override
+    public PurgeQueueResult purgeQueue(PurgeQueueRequest purgeQueueRequest) {
+        return underlyingConnection.purgeQueue(purgeQueueRequest);
+    }
+
+    @Override
+    public TagQueueResult tagQueue(TagQueueRequest tagQueueRequest) {
+        return underlyingConnection.tagQueue(tagQueueRequest);
+    }
+
+    @Override
+    public TagQueueResult tagQueue(String queueUrl, Map<String, String> tags) {
+        return underlyingConnection.tagQueue(queueUrl, tags);
+    }
+
+    @Override
+    public UntagQueueResult untagQueue(UntagQueueRequest untagQueueRequest) {
+        return underlyingConnection.untagQueue(untagQueueRequest);
+    }
+
+    @Override
+    public UntagQueueResult untagQueue(String queueUrl, List<String> tagKeys) {
+        return underlyingConnection.untagQueue(queueUrl, tagKeys);
+    }
+
+    // ... (Previous code)
+    @Override
+    public AddPermissionResult addPermission(AddPermissionRequest addPermissionRequest) {
+        return underlyingConnection.addPermission(addPermissionRequest);
+    }
+
+    @Override
+    public AddPermissionResult addPermission(String queueUrl, String label, List<String> awsAccountIds, List<String> actions) {
+        return underlyingConnection.addPermission(queueUrl, label, awsAccountIds, actions);
+    }
+
+    @Override
+    public CancelMessageMoveTaskResult cancelMessageMoveTask(CancelMessageMoveTaskRequest cancelMessageMoveTaskRequest) {
+        return underlyingConnection.cancelMessageMoveTask(cancelMessageMoveTaskRequest);
+    }
+
+    @Override
+    public ChangeMessageVisibilityResult changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest) {
+        return underlyingConnection.changeMessageVisibility(changeMessageVisibilityRequest);
+    }
+
+    @Override
+    public ChangeMessageVisibilityResult changeMessageVisibility(String queueUrl, String receiptHandle, Integer visibilityTimeout) {
+        return underlyingConnection.changeMessageVisibility(queueUrl, receiptHandle, visibilityTimeout);
+    }
+
+    @Override
+    public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(ChangeMessageVisibilityBatchRequest changeMessageVisibilityBatchRequest) {
+        return underlyingConnection.changeMessageVisibilityBatch(changeMessageVisibilityBatchRequest);
+    }
+
+    @Override
+    public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(String queueUrl, List<ChangeMessageVisibilityBatchRequestEntry> entries) {
+        return underlyingConnection.changeMessageVisibilityBatch(queueUrl, entries);
+    }
+
+    @Override
+    public ListDeadLetterSourceQueuesResult listDeadLetterSourceQueues(ListDeadLetterSourceQueuesRequest listDeadLetterSourceQueuesRequest) {
+        return underlyingConnection.listDeadLetterSourceQueues(listDeadLetterSourceQueuesRequest);
+    }
+
+    @Override
+    public ListMessageMoveTasksResult listMessageMoveTasks(ListMessageMoveTasksRequest listMessageMoveTasksRequest) {
+        return underlyingConnection.listMessageMoveTasks(listMessageMoveTasksRequest);
+    }
+
+    @Override
+    public RemovePermissionResult removePermission(RemovePermissionRequest removePermissionRequest) {
+        return underlyingConnection.removePermission(removePermissionRequest);
+    }
+
+    @Override
+    public RemovePermissionResult removePermission(String queueUrl, String label) {
+        return underlyingConnection.removePermission(queueUrl, label);
+    }
+
+    @Override
+    public StartMessageMoveTaskResult startMessageMoveTask(StartMessageMoveTaskRequest startMessageMoveTaskRequest) {
+        return underlyingConnection.startMessageMoveTask(startMessageMoveTaskRequest);
+    }
+
+    @Override
+    public ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest amazonWebServiceRequest) {
+        return underlyingConnection.getCachedResponseMetadata(amazonWebServiceRequest);
+    }
+
 }

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnection.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnection.java
@@ -39,6 +39,8 @@
  */
 package fish.payara.cloud.connectors.amazonsqs.api.outbound;
 
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.ResponseMetadata;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -47,11 +49,55 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.AddPermissionRequest;
+import com.amazonaws.services.sqs.model.AddPermissionResult;
+import com.amazonaws.services.sqs.model.CancelMessageMoveTaskRequest;
+import com.amazonaws.services.sqs.model.CancelMessageMoveTaskResult;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequest;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchResult;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityResult;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.CreateQueueResult;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchResult;
+import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageResult;
+import com.amazonaws.services.sqs.model.DeleteQueueRequest;
+import com.amazonaws.services.sqs.model.DeleteQueueResult;
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
+import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
+import com.amazonaws.services.sqs.model.GetQueueUrlResult;
+import com.amazonaws.services.sqs.model.ListDeadLetterSourceQueuesRequest;
+import com.amazonaws.services.sqs.model.ListDeadLetterSourceQueuesResult;
+import com.amazonaws.services.sqs.model.ListMessageMoveTasksRequest;
+import com.amazonaws.services.sqs.model.ListMessageMoveTasksResult;
+import com.amazonaws.services.sqs.model.ListQueueTagsRequest;
+import com.amazonaws.services.sqs.model.ListQueueTagsResult;
+import com.amazonaws.services.sqs.model.ListQueuesRequest;
+import com.amazonaws.services.sqs.model.ListQueuesResult;
+import com.amazonaws.services.sqs.model.PurgeQueueRequest;
+import com.amazonaws.services.sqs.model.PurgeQueueResult;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.RemovePermissionRequest;
+import com.amazonaws.services.sqs.model.RemovePermissionResult;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageBatchResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
+import com.amazonaws.services.sqs.model.SetQueueAttributesRequest;
+import com.amazonaws.services.sqs.model.SetQueueAttributesResult;
+import com.amazonaws.services.sqs.model.StartMessageMoveTaskRequest;
+import com.amazonaws.services.sqs.model.StartMessageMoveTaskResult;
+import com.amazonaws.services.sqs.model.TagQueueRequest;
+import com.amazonaws.services.sqs.model.TagQueueResult;
+import com.amazonaws.services.sqs.model.UntagQueueRequest;
+import com.amazonaws.services.sqs.model.UntagQueueResult;
 import com.amazonaws.util.StringUtils;
 import fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSConnection;
 
@@ -70,6 +116,7 @@ import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Steve Millidge (Payara Foundation)
@@ -82,7 +129,7 @@ public class AmazonSQSManagedConnection implements ManagedConnection, AmazonSQSC
     private final AmazonSQS sqsClient;
 
     AmazonSQSManagedConnection(Subject subject, ConnectionRequestInfo cxRequestInfo, AmazonSQSManagedConnectionFactory aThis) {
-        
+
         AWSCredentialsProvider credentialsProvider = getCredentials(aThis);
         sqsClient = AmazonSQSClientBuilder.standard().withRegion(aThis.getRegion()).withCredentials(credentialsProvider).build();
     }
@@ -196,6 +243,188 @@ public class AmazonSQSManagedConnection implements ManagedConnection, AmazonSQSC
     }
 
     @Override
+    public ReceiveMessageResult receiveMessage(ReceiveMessageRequest receiveMessageRequest) {
+        return sqsClient.receiveMessage(receiveMessageRequest);
+    }
+
+    @Override
+    public ReceiveMessageResult receiveMessage(String queueUrl) {
+        return sqsClient.receiveMessage(queueUrl);
+    }
+
+    @Override
+    public GetQueueAttributesResult getQueueAttributes(GetQueueAttributesRequest getQueueAttributesRequest) {
+        return sqsClient.getQueueAttributes(getQueueAttributesRequest);
+    }
+
+    @Override
+    public GetQueueAttributesResult getQueueAttributes(String queueUrl, List<String> attributeNames) {
+        return sqsClient.getQueueAttributes(queueUrl, attributeNames);
+    }
+
+    @Override
+    public SetQueueAttributesResult setQueueAttributes(SetQueueAttributesRequest setQueueAttributesRequest) {
+        return sqsClient.setQueueAttributes(setQueueAttributesRequest);
+    }
+
+    @Override
+    public SetQueueAttributesResult setQueueAttributes(String queueUrl, Map<String, String> attributes) {
+        return sqsClient.setQueueAttributes(queueUrl, attributes);
+    }
+
+    @Override
+    public CreateQueueResult createQueue(CreateQueueRequest createQueueRequest) {
+        return sqsClient.createQueue(createQueueRequest);
+    }
+
+    @Override
+    public CreateQueueResult createQueue(String queueName) {
+        return sqsClient.createQueue(queueName);
+    }
+
+    @Override
+    public DeleteMessageResult deleteMessage(DeleteMessageRequest deleteMessageRequest) {
+        return sqsClient.deleteMessage(deleteMessageRequest);
+    }
+
+    @Override
+    public DeleteMessageResult deleteMessage(String queueUrl, String receiptHandle) {
+        return sqsClient.deleteMessage(queueUrl, receiptHandle);
+    }
+
+    @Override
+    public DeleteMessageBatchResult deleteMessageBatch(DeleteMessageBatchRequest deleteMessageBatchRequest) {
+        return sqsClient.deleteMessageBatch(deleteMessageBatchRequest);
+    }
+
+    @Override
+    public DeleteMessageBatchResult deleteMessageBatch(String queueUrl, List<DeleteMessageBatchRequestEntry> entries) {
+        return sqsClient.deleteMessageBatch(queueUrl, entries);
+    }
+
+    @Override
+    public DeleteQueueResult deleteQueue(DeleteQueueRequest deleteQueueRequest) {
+        return sqsClient.deleteQueue(deleteQueueRequest);
+    }
+
+    @Override
+    public DeleteQueueResult deleteQueue(String queueUrl) {
+        return sqsClient.deleteQueue(queueUrl);
+    }
+
+    @Override
+    public GetQueueUrlResult getQueueUrl(GetQueueUrlRequest getQueueUrlRequest) {
+        return sqsClient.getQueueUrl(getQueueUrlRequest);
+    }
+
+    @Override
+    public GetQueueUrlResult getQueueUrl(String queueName) {
+        return sqsClient.getQueueUrl(queueName);
+    }
+
+    @Override
+    public ListQueueTagsResult listQueueTags(ListQueueTagsRequest listQueueTagsRequest) {
+        return sqsClient.listQueueTags(listQueueTagsRequest);
+    }
+
+    @Override
+    public ListQueueTagsResult listQueueTags(String queueUrl) {
+        return sqsClient.listQueueTags(queueUrl);
+    }
+
+    @Override
+    public ListQueuesResult listQueues(ListQueuesRequest listQueuesRequest) {
+        return sqsClient.listQueues(listQueuesRequest);
+    }
+
+    @Override
+    public ListQueuesResult listQueues() {
+        return sqsClient.listQueues();
+    }
+
+    @Override
+    public ListQueuesResult listQueues(String queueNamePrefix) {
+        return sqsClient.listQueues(queueNamePrefix);
+    }
+
+    @Override
+    public PurgeQueueResult purgeQueue(PurgeQueueRequest purgeQueueRequest) {
+        return sqsClient.purgeQueue(purgeQueueRequest);
+    }
+
+    @Override
+    public TagQueueResult tagQueue(TagQueueRequest tagQueueRequest) {
+        return sqsClient.tagQueue(tagQueueRequest);
+    }
+
+    @Override
+    public TagQueueResult tagQueue(String queueUrl, Map<String, String> tags) {
+        return sqsClient.tagQueue(queueUrl, tags);
+    }
+
+    @Override
+    public UntagQueueResult untagQueue(UntagQueueRequest untagQueueRequest) {
+        return sqsClient.untagQueue(untagQueueRequest);
+    }
+
+    @Override
+    public UntagQueueResult untagQueue(String queueUrl, List<String> tagKeys) {
+        return sqsClient.untagQueue(queueUrl, tagKeys);
+    }
+
+    public AddPermissionResult addPermission(AddPermissionRequest addPermissionRequest) {
+        return sqsClient.addPermission(addPermissionRequest);
+    }
+
+    public AddPermissionResult addPermission(String queueUrl, String label, List<String> awsAccountIds, List<String> actions) {
+        return sqsClient.addPermission(queueUrl, label, awsAccountIds, actions);
+    }
+
+    public CancelMessageMoveTaskResult cancelMessageMoveTask(CancelMessageMoveTaskRequest cancelMessageMoveTaskRequest) {
+        return sqsClient.cancelMessageMoveTask(cancelMessageMoveTaskRequest);
+    }
+
+    public ChangeMessageVisibilityResult changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest) {
+        return sqsClient.changeMessageVisibility(changeMessageVisibilityRequest);
+    }
+
+    public ChangeMessageVisibilityResult changeMessageVisibility(String queueUrl, String receiptHandle, Integer visibilityTimeout) {
+        return sqsClient.changeMessageVisibility(queueUrl, receiptHandle, visibilityTimeout);
+    }
+
+    public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(ChangeMessageVisibilityBatchRequest changeMessageVisibilityBatchRequest) {
+        return sqsClient.changeMessageVisibilityBatch(changeMessageVisibilityBatchRequest);
+    }
+
+    public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(String queueUrl, List<ChangeMessageVisibilityBatchRequestEntry> entries) {
+        return sqsClient.changeMessageVisibilityBatch(queueUrl, entries);
+    }
+
+    public ListDeadLetterSourceQueuesResult listDeadLetterSourceQueues(ListDeadLetterSourceQueuesRequest listDeadLetterSourceQueuesRequest) {
+        return sqsClient.listDeadLetterSourceQueues(listDeadLetterSourceQueuesRequest);
+    }
+
+    public ListMessageMoveTasksResult listMessageMoveTasks(ListMessageMoveTasksRequest listMessageMoveTasksRequest) {
+        return sqsClient.listMessageMoveTasks(listMessageMoveTasksRequest);
+    }
+
+    public RemovePermissionResult removePermission(RemovePermissionRequest removePermissionRequest) {
+        return sqsClient.removePermission(removePermissionRequest);
+    }
+
+    public RemovePermissionResult removePermission(String queueUrl, String label) {
+        return sqsClient.removePermission(queueUrl, label);
+    }
+
+    public StartMessageMoveTaskResult startMessageMoveTask(StartMessageMoveTaskRequest startMessageMoveTaskRequest) {
+        return sqsClient.startMessageMoveTask(startMessageMoveTaskRequest);
+    }
+
+    public ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest amazonWebServiceRequest) {
+        return sqsClient.getCachedResponseMetadata(amazonWebServiceRequest);
+    }
+
+    @Override
     public void close() throws Exception {
         destroy();
     }
@@ -206,7 +435,7 @@ public class AmazonSQSManagedConnection implements ManagedConnection, AmazonSQSC
             credentialsProvider = STSCredentialsProvider.create(aThis.getRoleArn(), aThis.getRoleSessionName(), Regions.fromName(aThis.getRegion()));
         } else if (!StringUtils.isNullOrEmpty(aThis.getProfileName())) {
             credentialsProvider = new ProfileCredentialsProvider(aThis.getProfileName());
-        } else if (!StringUtils.isNullOrEmpty(aThis.getAwsAccessKeyId()) && !StringUtils.isNullOrEmpty(aThis.getAwsSecretKey()) ) {
+        } else if (!StringUtils.isNullOrEmpty(aThis.getAwsAccessKeyId()) && !StringUtils.isNullOrEmpty(aThis.getAwsSecretKey())) {
             credentialsProvider = new AWSStaticCredentialsProvider(new AWSCredentials() {
                 @Override
                 public String getAWSAccessKeyId() {


### PR DESCRIPTION
### Description:
This pull request introduces new features to the Amazon SQS Connector within our Ecosystem Tools. The enhancements aim to provide a comprehensive set of actions available in the AWS SqsClient class. The following features have been implemented:

1. **Creating Queues:**
   - Method: `SqsClient.createQueue(CreateQueueRequest createQueueRequest)`
   - Method: `SqsClient.createQueue(String queueName)`

2. **Deleting Queues:**
   - Method: `SqsClient.deleteQueue(DeleteQueueRequest deleteQueueRequest)`
   - Method: `SqsClient.deleteQueue(String queueUrl)`

3. **Queue URL Builder:**
   - Method: `SqsClient.getQueueUrl(GetQueueUrlRequest getQueueUrlRequest)`
   - Method: `SqsClient.getQueueUrl(String queueName)`

4. **Listing Queues:**
   - Method: `SqsClient.listQueues()`
   - Method: `SqsClient.listQueues(ListQueuesRequest listQueuesRequest)`
   - Method: `SqsClient.listQueues(String queueNamePrefix)`

5. **Retrieving Queue Attributes:**
   - Method: `SqsClient.getQueueAttributes(GetQueueAttributesRequest getQueueAttributesRequest)`
   - Method: `SqsClient.getQueueAttributes(String queueUrl, List<String> attributeNames)`

6. **Receiving Messages:**
   - Method: `SqsClient.receiveMessage(ReceiveMessageRequest receiveMessageRequest)`
   - Method: `SqsClient.receiveMessage(String queueUrl)`

7. **Additional Methods from AWS SqsClient Class:**
   - Methods for managing permissions, purging queues, tagging, untagging, and more.

### Implementation Details:
- The new methods have been added to the `AmazonSQSConnection` interface.
- The implementations of these methods have been added to the corresponding classes by delegating to SQSClient.

