### PR TITLE
FISH-7822 Add Support for Amazon SQS Extended Client Library

### DIFF
--- a/AmazonSQS/AmazonSQSJCAAPI/pom.xml
+++ b/AmazonSQS/AmazonSQSJCAAPI/pom.xml
@@ -33,5 +33,15 @@
             <version>1.12.661</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.12.661</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
+            <version>1.2.5</version>
+        </dependency>
     </dependencies>
 </project>

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/AmazonSQSActivationSpec.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/AmazonSQSActivationSpec.java
@@ -51,6 +51,7 @@ import fish.payara.cloud.connectors.amazonsqs.api.outbound.STSCredentialsProvide
 import javax.resource.ResourceException;
 import javax.resource.spi.Activation;
 import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.ConfigProperty;
 import javax.resource.spi.InvalidPropertyException;
 import javax.resource.spi.ResourceAdapter;
 
@@ -78,6 +79,10 @@ public class AmazonSQSActivationSpec implements ActivationSpec, AWSCredentialsPr
     private String profileName;
     private String roleArn;
     private String roleSessionName;
+    private String s3BucketName;
+    private Integer s3SizeThreshold = 0;
+    private String s3KeyPrefix;
+    private Boolean s3FetchMessage = true;
 
     @Override
     public void validate() throws InvalidPropertyException {
@@ -203,7 +208,39 @@ public class AmazonSQSActivationSpec implements ActivationSpec, AWSCredentialsPr
     public void setRoleSessionName(String roleSessionName) {
         this.roleSessionName = roleSessionName;
     }
-    
+
+    public String getS3BucketName() {
+        return s3BucketName;
+    }
+
+    public void setS3BucketName(String s3BucketName) {
+        this.s3BucketName = s3BucketName;
+    }
+
+    public Integer getS3SizeThreshold() {
+        return s3SizeThreshold;
+    }
+
+    public void setS3SizeThreshold(Integer s3SizeThreshold) {
+        this.s3SizeThreshold = s3SizeThreshold;
+    }
+
+    public String getS3KeyPrefix() {
+        return s3KeyPrefix;
+    }
+
+    public void setS3KeyPrefix(String s3KeyPrefix) {
+        this.s3KeyPrefix = s3KeyPrefix;
+    }
+
+    public Boolean getS3FetchMessage() {
+        return s3FetchMessage;
+    }
+
+    public void setS3FetchMessage(Boolean s3FetchMessage) {
+        this.s3FetchMessage = s3FetchMessage;
+    }
+
     @Override
     public AWSCredentials getCredentials() {
 

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
@@ -78,7 +78,7 @@ class SQSPoller extends TimerTask {
     private final MessageEndpointFactory factory;
     private final AmazonSQS client;
     private AmazonS3 s3;
-    private static final String S3_BUCKET_NAME_KEY = "s3BucketName";
+    private static final String S3_BUCKET_NAME = "s3BucketName";
     private static final String S3_KEY = "s3Key";
     private static final Logger LOG = Logger.getLogger(SQSPoller.class.getName());
 
@@ -130,7 +130,7 @@ class SQSPoller extends TimerTask {
     private boolean shouldFetchS3Message(Message message) {
         return s3 != null
                 && Boolean.TRUE.equals(spec.getS3FetchMessage())
-                && message.getBody().contains(S3_BUCKET_NAME_KEY);
+                && message.getBody().contains(S3_BUCKET_NAME);
     }
 
     private void fetchS3MessageContent(Message message) throws IOException {
@@ -139,8 +139,8 @@ class SQSPoller extends TimerTask {
             for (JsonValue jsonValue : jsonArray) {
                 if (jsonValue instanceof JsonObject) {
                     JsonObject jsonBody = (JsonObject) jsonValue;
-                    String s3BucketName = jsonBody.getString(S3_BUCKET_NAME_KEY);
-                    String s3Key = jsonBody.getString(S3_KEY_KEY);
+                    String s3BucketName = jsonBody.getString(S3_BUCKET_NAME);
+                    String s3Key = jsonBody.getString(S3_KEY);
                     LOG.log(Level.FINE, "S3 object received, S3 bucket name: {0}, S3 object key:{1}", new Object[]{s3BucketName, s3Key});
                     GetObjectRequest getObjectRequest = new GetObjectRequest(s3BucketName, s3Key);
                     S3Object s3Object = s3.getObject(getObjectRequest);

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,17 +39,29 @@
  */
 package fish.payara.cloud.connectors.amazonsqs.api.inbound;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import fish.payara.cloud.connectors.amazonsqs.api.OnSQSMessage;
+import java.io.IOException;
+import java.io.StringReader;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
 import javax.resource.spi.BootstrapContext;
 import javax.resource.spi.endpoint.MessageEndpointFactory;
 import javax.resource.spi.work.WorkException;
@@ -59,11 +71,15 @@ import javax.resource.spi.work.WorkException;
  * @author Steve Millidge (Payara Foundation)
  */
 class SQSPoller extends TimerTask {
-    
-    AmazonSQSActivationSpec spec;
-    BootstrapContext ctx;
-    MessageEndpointFactory factory;
-    AmazonSQS client;
+
+    private final AmazonSQSActivationSpec spec;
+    private final BootstrapContext ctx;
+    private final MessageEndpointFactory factory;
+    private final AmazonSQS client;
+    private AmazonS3 s3;
+    private static final String S3_BUCKET_NAME_KEY = "s3BucketName";
+    private static final String S3_KEY_KEY = "s3Key";
+    private static final Logger LOG = Logger.getLogger(SQSPoller.class.getName());
 
     SQSPoller(AmazonSQSActivationSpec sqsSpec, BootstrapContext context, MessageEndpointFactory endpointFactory) {
         spec = sqsSpec;
@@ -78,36 +94,78 @@ class SQSPoller extends TimerTask {
             ReceiveMessageRequest rmr = new ReceiveMessageRequest(spec.getQueueURL());
             rmr.setMaxNumberOfMessages(spec.getMaxMessages());
             rmr.setVisibilityTimeout(spec.getVisibilityTimeout());
-            rmr.setWaitTimeSeconds(spec.getPollInterval()/1000);
+            rmr.setWaitTimeSeconds(spec.getPollInterval() / 1000);
             rmr.setAttributeNames(Arrays.asList(spec.getAttributeNames().split(",")));
             rmr.setMessageAttributeNames(Arrays.asList(spec.getMessageAttributeNames().split(",")));
             ReceiveMessageResult rmResult = client.receiveMessage(rmr);
             if (!rmResult.getMessages().isEmpty()) {
-
                 Class<?> mdbClass = factory.getEndpointClass();
                 for (Message message : rmResult.getMessages()) {
                     for (Method m : mdbClass.getMethods()) {
-                        if (m.isAnnotationPresent(OnSQSMessage.class) && m.getParameterCount() == 1 && m.getParameterTypes()[0].equals(Message.class)) {
-                            try {
-                                ctx.getWorkManager().scheduleWork(new SQSWork(client, factory, m, message,spec.getQueueURL()));
-                            } catch (WorkException ex) {
-                                Logger.getLogger(AmazonSQSResourceAdapter.class.getName()).log(Level.SEVERE, null, ex);
-                            }
+                        if (isOnSQSMessageMethod(m, message) && shouldFetchS3Message(message)) {
+                            fetchS3MessageContent(message);
+                            scheduleSQSWork(m, message);
                         }
                     }
-
                 }
             }
         } catch (IllegalStateException ise) {
             // Fix #29 ensure Illegal State Exception doesn't blow up the timer
-            Logger.getLogger(AmazonSQSResourceAdapter.class.getName()).log(Level.WARNING, "Poller caught an Illegal State Exception", ise);
-        } catch(Exception e) {
-            Logger.getLogger(AmazonSQSResourceAdapter.class.getName()).log(Level.WARNING, "Poller caught an Unexpected Exception", e);            
+            LOG.log(Level.WARNING, "Poller caught an Illegal State Exception", ise);
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Poller caught an Unexpected Exception", e);
+        }
+    }
+
+    private boolean isOnSQSMessageMethod(Method method, Message message) {
+        return method.isAnnotationPresent(OnSQSMessage.class)
+                && method.getParameterCount() == 1
+                && method.getParameterTypes()[0].equals(Message.class);
+    }
+
+    private boolean shouldFetchS3Message(Message message) {
+        return s3 != null
+                && Boolean.TRUE.equals(spec.getS3FetchMessage())
+                && message.getBody().contains(S3_BUCKET_NAME_KEY);
+    }
+
+    private void fetchS3MessageContent(Message message) throws IOException {
+        try (JsonReader jsonReader = Json.createReader(new StringReader(message.getBody()))) {
+            JsonArray jsonArray = jsonReader.readArray();
+            for (JsonValue jsonValue : jsonArray) {
+                if (jsonValue instanceof JsonObject) {
+                    JsonObject jsonBody = (JsonObject) jsonValue;
+                    String s3BucketName = jsonBody.getString(S3_BUCKET_NAME_KEY);
+                    String s3Key = jsonBody.getString(S3_KEY_KEY);
+                    LOG.log(Level.FINE, "S3 object received, S3 bucket name: {0}, S3 object key:{1}", new Object[]{s3BucketName, s3Key});
+                    GetObjectRequest getObjectRequest = new GetObjectRequest(s3BucketName, s3Key);
+                    S3Object s3Object = s3.getObject(getObjectRequest);
+                    try (S3ObjectInputStream objectInputStream = s3Object.getObjectContent()) {
+                        byte[] buffer = new byte[1024];
+                        int bytesRead;
+                        StringBuilder content = new StringBuilder();
+                        while ((bytesRead = objectInputStream.read(buffer)) != -1) {
+                            content.append(new String(buffer, 0, bytesRead));
+                        }
+                        message.setBody(content.toString());
+                    }
+                }
+            }
+        } catch (JsonException e) {
+            LOG.log(Level.WARNING, "Error parsing S3 message metadata JSON", e);
+        }
+    }
+
+    private void scheduleSQSWork(Method method, Message message) {
+        try {
+            ctx.getWorkManager().scheduleWork(new SQSWork(client, factory, method, message, spec.getQueueURL()));
+        } catch (WorkException ex) {
+            Logger.getLogger(AmazonSQSResourceAdapter.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 
     void stop() {
         client.shutdown();
     }
-    
+
 }

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
@@ -79,7 +79,7 @@ class SQSPoller extends TimerTask {
     private final AmazonSQS client;
     private AmazonS3 s3;
     private static final String S3_BUCKET_NAME_KEY = "s3BucketName";
-    private static final String S3_KEY_KEY = "s3Key";
+    private static final String S3_KEY = "s3Key";
     private static final Logger LOG = Logger.getLogger(SQSPoller.class.getName());
 
     SQSPoller(AmazonSQSActivationSpec sqsSpec, BootstrapContext context, MessageEndpointFactory endpointFactory) {

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
@@ -82,6 +82,18 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
     @ConfigProperty(description = "AWS Session name", type = String.class)
     private String roleSessionName;
 
+    @ConfigProperty(description = "AWS S3 bucket name", type = String.class)
+    private String s3BucketName;
+
+    @ConfigProperty(description = "AWS S3 size threshold", type = Integer.class, defaultValue ="0")
+    private Integer s3SizeThreshold;
+
+    @ConfigProperty(description = "AWS S3 key prefix", type = String.class)
+    private String s3KeyPrefix;
+
+    @ConfigProperty(description = "AWS S3 fetch message", type = Boolean.class, defaultValue ="true")
+    private Boolean s3FetchMessage;
+
     private PrintWriter logger;
 
     public String getAwsSecretKey() {
@@ -130,6 +142,38 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
 
     public void setRoleSessionName(String roleSessionName) {
         this.roleSessionName = roleSessionName;
+    }
+
+    public String getS3BucketName() {
+        return s3BucketName;
+    }
+
+    public void setS3BucketName(String s3BucketName) {
+        this.s3BucketName = s3BucketName;
+    }
+
+    public Integer getS3SizeThreshold() {
+        return s3SizeThreshold;
+    }
+
+    public void setS3SizeThreshold(Integer s3SizeThreshold) {
+        this.s3SizeThreshold = s3SizeThreshold;
+    }
+
+    public String getS3KeyPrefix() {
+        return s3KeyPrefix;
+    }
+
+    public void setS3KeyPrefix(String s3KeyPrefix) {
+        this.s3KeyPrefix = s3KeyPrefix;
+    }
+
+    public Boolean getS3FetchMessage() {
+        return s3FetchMessage;
+    }
+
+    public void setS3FetchMessage(Boolean s3FetchMessage) {
+        this.s3FetchMessage = s3FetchMessage;
     }
 
     @Override

--- a/AmazonSQS/AmazonSQSRAR/pom.xml
+++ b/AmazonSQS/AmazonSQSRAR/pom.xml
@@ -37,5 +37,15 @@
             <version>1.12.661</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.12.661</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
+            <version>1.2.5</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This pull request introduces extended support for larger messages in the Amazon SQS Cloud Connector. The AWS Java SDK has a message size limitation of 256KB, which can be restrictive for certain use cases. To overcome this limitation, we've integrated the SQS Extended Client Library, an external plugin developed by AWS. This library enables the handling of larger messages (up to 2GB) by storing the message payload in an AWS S3 bucket while including a pointer to its contents in the SQS message.

### Configuration Properties:

`s3BucketName`: AWS S3 bucket name (Type: String)
`s3SizeThreshold`: AWS S3 size threshold (Type: Integer, Default: 0)
`s3KeyPrefix`: AWS S3 key prefix (Type: String)
`s3FetchMessage`: AWS S3 fetch message (Type: Boolean, Default: true)

### Testing

To test this feature:
1- Create an S3 bucket in AWS
2- Add AmazonS3FullAccess permission to IAM role.
3- Utilize the provided sample code to generate and send larger messages. Ensure that the S3 bucket name matches the configured s3BucketName property.
```
@ConnectionFactoryDefinition(name = "java:comp/env/SQSConnectionFactory",
        description = "SQS Conn Factory",
        interfaceName = "fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSConnectionFactory",
        resourceAdapter = "amazon-sqs-rar-0.8.0",
        minPoolSize = 2, maxPoolSize = 2,
        transactionSupport = TransactionSupportLevel.NoTransaction,
        properties = {"region=ap-south-1", "s3BucketName=MyS3Bucket"}
)
@Stateless
public class NewTimerSessionBean {

    @Resource(lookup = "java:comp/env/SQSConnectionFactory")
    AmazonSQSConnectionFactory factory;

    @Schedule(second = "0", hour = "*", minute = "*/2", persistent = false)
    public void myTimer() {
        try (AmazonSQSConnection connection = factory.getConnection()) {
            connection.sendMessage(new SendMessageRequest("https://sqs.ap-south-1.amazonaws.com/185040379064/MyQueue", createLargeMessage()));
        } catch (Exception e) {
            e.printStackTrace();
            System.out.println(e.getMessage());
        }
    }

    private static String createLargeMessage() {
        StringBuilder largeMessageBuilder = new StringBuilder();
        while (largeMessageBuilder.length() < 258 * 1024) {
            largeMessageBuilder.append("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ");
        }
        return largeMessageBuilder.toString();
    }
}
```

