### PR TITLE
FISH-7822 Add Support for Amazon SQS Extended Client Library

### DIFF
--- a/AmazonSQS/AmazonSQSJCAAPI/pom.xml
+++ b/AmazonSQS/AmazonSQSJCAAPI/pom.xml
@@ -78,5 +78,15 @@ holder.
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.12.661</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
+            <version>1.2.5</version>
+        </dependency>
     </dependencies>
 </project>

--- a/AmazonSQS/AmazonSQSJCAAPI/pom.xml
+++ b/AmazonSQS/AmazonSQSJCAAPI/pom.xml
@@ -79,14 +79,13 @@ holder.
             <artifactId>sts</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.661</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-            <version>1.2.5</version>
+            <version>2.0.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/AmazonSQSActivationSpec.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/AmazonSQSActivationSpec.java
@@ -77,6 +77,10 @@ public class AmazonSQSActivationSpec implements ActivationSpec, AwsCredentialsPr
     private String profileName;
     private String roleArn;
     private String roleSessionName;
+    private String s3BucketName;
+    private Integer s3SizeThreshold = 0;
+    private String s3KeyPrefix;
+    private Boolean s3FetchMessage = true;
 
     @Override
     public void validate() throws InvalidPropertyException {
@@ -201,6 +205,38 @@ public class AmazonSQSActivationSpec implements ActivationSpec, AwsCredentialsPr
 
     public void setRoleSessionName(String roleSessionName) {
         this.roleSessionName = roleSessionName;
+    }
+
+    public String getS3BucketName() {
+        return s3BucketName;
+    }
+
+    public void setS3BucketName(String s3BucketName) {
+        this.s3BucketName = s3BucketName;
+    }
+
+    public Integer getS3SizeThreshold() {
+        return s3SizeThreshold;
+    }
+
+    public void setS3SizeThreshold(Integer s3SizeThreshold) {
+        this.s3SizeThreshold = s3SizeThreshold;
+    }
+
+    public String getS3KeyPrefix() {
+        return s3KeyPrefix;
+    }
+
+    public void setS3KeyPrefix(String s3KeyPrefix) {
+        this.s3KeyPrefix = s3KeyPrefix;
+    }
+
+    public Boolean getS3FetchMessage() {
+        return s3FetchMessage;
+    }
+
+    public void setS3FetchMessage(Boolean s3FetchMessage) {
+        this.s3FetchMessage = s3FetchMessage;
     }
 
     @Override

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
@@ -79,7 +79,7 @@ class SQSPoller extends TimerTask {
     private final MessageEndpointFactory factory;
     private final SqsClient client;
     private S3Client s3;
-    private static final String S3_BUCKET_NAME_KEY = "s3BucketName";
+    private static final String S3_BUCKET_NAME = "s3BucketName";
     private static final String S3_KEY = "s3Key";
     private static final Logger LOG = Logger.getLogger(SQSPoller.class.getName());
 
@@ -134,7 +134,7 @@ class SQSPoller extends TimerTask {
     private boolean shouldFetchS3Message(Message message) {
         return s3 != null
                 && Boolean.TRUE.equals(spec.getS3FetchMessage())
-                && message.body().contains(S3_BUCKET_NAME_KEY);
+                && message.body().contains(S3_BUCKET_NAME);
     }
 
     private Message fetchS3MessageContent(Message message) throws IOException {
@@ -144,7 +144,7 @@ class SQSPoller extends TimerTask {
             for (JsonValue jsonValue : jsonArray) {
                 if (jsonValue instanceof JsonObject) {
                     JsonObject jsonBody = (JsonObject) jsonValue;
-                    String s3BucketName = jsonBody.getString(S3_BUCKET_NAME_KEY);
+                    String s3BucketName = jsonBody.getString(S3_BUCKET_NAME);
                     String s3Key = jsonBody.getString(S3_KEY);
                     LOG.log(Level.FINE, "S3 object received, S3 bucket name: {0}, S3 object key:{1}", new Object[]{s3BucketName, s3Key});
                     GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(s3BucketName).key(s3Key).build();

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
@@ -80,7 +80,7 @@ class SQSPoller extends TimerTask {
     private final SqsClient client;
     private S3Client s3;
     private static final String S3_BUCKET_NAME_KEY = "s3BucketName";
-    private static final String S3_KEY_KEY = "s3Key";
+    private static final String S3_KEY = "s3Key";
     private static final Logger LOG = Logger.getLogger(SQSPoller.class.getName());
 
     SQSPoller(AmazonSQSActivationSpec sqsSpec, BootstrapContext context, MessageEndpointFactory endpointFactory) {

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPoller.java
@@ -145,7 +145,7 @@ class SQSPoller extends TimerTask {
                 if (jsonValue instanceof JsonObject) {
                     JsonObject jsonBody = (JsonObject) jsonValue;
                     String s3BucketName = jsonBody.getString(S3_BUCKET_NAME_KEY);
-                    String s3Key = jsonBody.getString(S3_KEY_KEY);
+                    String s3Key = jsonBody.getString(S3_KEY);
                     LOG.log(Level.FINE, "S3 object received, S3 bucket name: {0}, S3 object key:{1}", new Object[]{s3BucketName, s3Key});
                     GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(s3BucketName).key(s3Key).build();
                     ResponseInputStream<GetObjectResponse> responseInputStream = s3.getObject(getObjectRequest);

--- a/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/main/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactory.java
@@ -82,6 +82,18 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
     @ConfigProperty(description = "AWS Session name", type = String.class)
     private String roleSessionName;
 
+    @ConfigProperty(description = "AWS S3 bucket name", type = String.class)
+    private String s3BucketName;
+
+    @ConfigProperty(description = "AWS S3 size threshold", type = Integer.class, defaultValue ="0")
+    private Integer s3SizeThreshold;
+
+    @ConfigProperty(description = "AWS S3 key prefix", type = String.class)
+    private String s3KeyPrefix;
+
+    @ConfigProperty(description = "AWS S3 fetch message", type = Boolean.class, defaultValue ="true")
+    private Boolean s3FetchMessage;
+
     private PrintWriter logger;
 
     public String getAwsSecretKey() {
@@ -130,6 +142,38 @@ public class AmazonSQSManagedConnectionFactory implements ManagedConnectionFacto
 
     public void setRoleSessionName(String roleSessionName) {
         this.roleSessionName = roleSessionName;
+    }
+
+    public String getS3BucketName() {
+        return s3BucketName;
+    }
+
+    public void setS3BucketName(String s3BucketName) {
+        this.s3BucketName = s3BucketName;
+    }
+
+    public Integer getS3SizeThreshold() {
+        return s3SizeThreshold;
+    }
+
+    public void setS3SizeThreshold(Integer s3SizeThreshold) {
+        this.s3SizeThreshold = s3SizeThreshold;
+    }
+
+    public String getS3KeyPrefix() {
+        return s3KeyPrefix;
+    }
+
+    public void setS3KeyPrefix(String s3KeyPrefix) {
+        this.s3KeyPrefix = s3KeyPrefix;
+    }
+
+    public Boolean getS3FetchMessage() {
+        return s3FetchMessage;
+    }
+
+    public void setS3FetchMessage(Boolean s3FetchMessage) {
+        this.s3FetchMessage = s3FetchMessage;
     }
 
     @Override

--- a/AmazonSQS/AmazonSQSRAR/pom.xml
+++ b/AmazonSQS/AmazonSQSRAR/pom.xml
@@ -81,14 +81,14 @@ holder.
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.661</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-            <version>1.2.5</version>
+            <version>2.0.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/AmazonSQS/AmazonSQSRAR/pom.xml
+++ b/AmazonSQS/AmazonSQSRAR/pom.xml
@@ -80,5 +80,15 @@ holder.
             <version>${awssdk.version}</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.12.661</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
+            <version>1.2.5</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This pull request introduces extended support for larger messages in the Amazon SQS Cloud Connector. The AWS Java SDK has a message size limitation of 256KB, which can be restrictive for certain use cases. To overcome this limitation, we've integrated the SQS Extended Client Library, an external plugin developed by AWS. This library enables the handling of larger messages (up to 2GB) by storing the message payload in an AWS S3 bucket while including a pointer to its contents in the SQS message.

### Configuration Properties:

`s3BucketName`: AWS S3 bucket name (Type: String)
`s3SizeThreshold`: AWS S3 size threshold (Type: Integer, Default: 0)
`s3KeyPrefix`: AWS S3 key prefix (Type: String)
`s3FetchMessage`: AWS S3 fetch message (Type: Boolean, Default: true)

### Testing

To test this feature:
1- Create an S3 bucket in AWS
2- Add AmazonS3FullAccess permission to IAM role.
3- Utilize the provided sample code to generate and send larger messages. Ensure that the S3 bucket name matches the configured s3BucketName property.
```
@ConnectionFactoryDefinition(name = "java:comp/env/SQSConnectionFactory",
        description = "SQS Conn Factory",
        interfaceName = "fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSConnectionFactory",
        resourceAdapter = "amazon-sqs-rar-0.8.0",
        minPoolSize = 2, maxPoolSize = 2,
        transactionSupport = TransactionSupportLevel.NoTransaction,
        properties = {"region=ap-south-1", "s3BucketName=MyS3Bucket"}
)
@Stateless
public class NewTimerSessionBean {

    @Resource(lookup = "java:comp/env/SQSConnectionFactory")
    AmazonSQSConnectionFactory factory;

    @Schedule(second = "0", hour = "*", minute = "*/2", persistent = false)
public void myTimer() {
        try (AmazonSQSConnection connection = factory.getConnection()) {
            SendMessageRequest sendMsgRequest = SendMessageRequest.builder()
                    .queueUrl("https://sqs.ap-south-1.amazonaws.com/185040379064/MyQueue")
                    .messageBody(createLargeMessage())
                    .build();
            connection.sendMessage(sendMsgRequest);
        } catch (Exception e) {
            System.out.println(e.toString());
        }
    }

    private static String createLargeMessage() {
        StringBuilder largeMessageBuilder = new StringBuilder();
        while (largeMessageBuilder.length() < 258 * 1024) {
            largeMessageBuilder.append("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ");
        }
        return largeMessageBuilder.toString();
    }
}
```

