### PR TITLE
Fish 12117 add unit tests amazon sqs

### DIFF
--- a/AmazonSQS/AmazonSQSJCAAPI/pom.xml
+++ b/AmazonSQS/AmazonSQSJCAAPI/pom.xml
@@ -87,5 +87,39 @@ holder.
             <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
             <version>2.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.13.0-M3</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.15.2</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPollerTest.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPollerTest.java
@@ -1,0 +1,198 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.amazonsqs.api.inbound;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonWriter;
+import jakarta.resource.spi.BootstrapContext;
+import jakarta.resource.spi.endpoint.MessageEndpointFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SQSPollerTest {
+
+    private AmazonSQSActivationSpec spec;
+    private BootstrapContext ctx;
+    private MessageEndpointFactory factory;
+    private SqsClient sqsClient;
+    private S3Client s3Client;
+    private SQSPoller poller;
+
+    @BeforeEach
+    void setUp() {
+        spec = mock(AmazonSQSActivationSpec.class);
+        ctx = mock(BootstrapContext.class);
+        factory = mock(MessageEndpointFactory.class);
+        sqsClient = mock(SqsClient.class);
+        s3Client = mock(S3Client.class);
+
+        when(spec.getRegion()).thenReturn("us-east-1");
+        when(spec.getQueueURL()).thenReturn("queue-url");
+        when(spec.getMaxMessages()).thenReturn(1);
+        when(spec.getVisibilityTimeout()).thenReturn(30);
+        when(spec.getPollInterval()).thenReturn(1000);
+        when(spec.getAttributeNames()).thenReturn("All");
+        when(spec.getMessageAttributeNames()).thenReturn("All");
+    }
+
+    @Test
+    void testFetchS3MessageContentReturnsUpdatedMessage() throws Exception {
+        // Prepare JSON body with S3 info
+        JsonObjectBuilder objBuilder = Json.createObjectBuilder()
+                .add("s3BucketName", "bucket")
+                .add("s3Key", "key");
+        JsonArrayBuilder arrBuilder = Json.createArrayBuilder().add(objBuilder);
+        StringWriter sw = new StringWriter();
+        try (JsonWriter writer = Json.createWriter(sw)) {
+            writer.writeArray(arrBuilder.build());
+        }
+        String jsonBody = sw.toString();
+
+        // Mock S3 client and response
+        S3Client s3 = mock(S3Client.class);
+        String s3Content = "file-content";
+        InputStream is = new ByteArrayInputStream(s3Content.getBytes());
+        ResponseInputStream<GetObjectResponse> responseInputStream = mock(ResponseInputStream.class);
+        when(responseInputStream.readAllBytes()).thenReturn(s3Content.getBytes());
+        when(s3.getObject(any(GetObjectRequest.class))).thenReturn(responseInputStream);
+
+        // Build original message
+        Message origMsg = Message.builder()
+                .body(jsonBody)
+                .messageId("mid")
+                .receiptHandle("rh")
+                .build();
+
+        // Use reflection to inject s3 client into poller
+        poller = new SQSPoller(spec, ctx, factory);
+        var s3Field = SQSPoller.class.getDeclaredField("s3");
+        s3Field.setAccessible(true);
+        s3Field.set(poller, s3);
+
+        // Mock IoUtils.toUtf8String
+        try (var mockedIoUtils = org.mockito.Mockito.mockStatic(software.amazon.awssdk.utils.IoUtils.class)) {
+            mockedIoUtils.when(() -> software.amazon.awssdk.utils.IoUtils.toUtf8String(responseInputStream))
+                    .thenReturn(s3Content);
+
+            Message updated = poller.fetchS3MessageContent(origMsg);
+
+            assertNotNull(updated);
+            assertEquals(s3Content, updated.body());
+            assertEquals(origMsg.messageId(), updated.messageId());
+            assertEquals(origMsg.receiptHandle(), updated.receiptHandle());
+        }
+    }
+
+    @Test
+    void testFetchS3MessageContentHandlesJsonException() throws Exception {
+        // Invalid JSON body
+        String invalidJson = "not a json";
+        Message origMsg = Message.builder().body(invalidJson).build();
+
+        poller = new SQSPoller(spec, ctx, factory);
+
+        // Should not throw, should return original message
+        Message result = poller.fetchS3MessageContent(origMsg);
+        assertEquals(origMsg, result);
+    }
+
+    @Test
+    void testShouldFetchS3MessageReturnsTrue() throws Exception {
+        poller = new SQSPoller(spec, ctx, factory);
+        var s3Field = SQSPoller.class.getDeclaredField("s3");
+        s3Field.setAccessible(true);
+        s3Field.set(poller, mock(S3Client.class));
+
+        when(spec.getS3FetchMessage()).thenReturn(true);
+
+        Message msg = Message.builder().body("s3BucketName").build();
+        var method = SQSPoller.class.getDeclaredMethod("shouldFetchS3Message", Message.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(poller, msg);
+        assertTrue(result);
+    }
+
+    @Test
+    void testShouldFetchS3MessageReturnsFalseIfNoS3() throws Exception {
+        poller = new SQSPoller(spec, ctx, factory);
+        when(spec.getS3FetchMessage()).thenReturn(true);
+
+        Message msg = Message.builder().body("s3BucketName").build();
+        var method = SQSPoller.class.getDeclaredMethod("shouldFetchS3Message", Message.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(poller, msg);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsOnSQSMessageMethod() throws Exception {
+        poller = new SQSPoller(spec, ctx, factory);
+
+        class Dummy {
+            @fish.payara.cloud.connectors.amazonsqs.api.OnSQSMessage
+            public void handle(software.amazon.awssdk.services.sqs.model.Message msg) {}
+            public void notHandle(String s) {}
+        }
+        Method m1 = Dummy.class.getMethod("handle", software.amazon.awssdk.services.sqs.model.Message.class);
+        Method m2 = Dummy.class.getMethod("notHandle", String.class);
+
+        var method = SQSPoller.class.getDeclaredMethod("isOnSQSMessageMethod", Method.class);
+        method.setAccessible(true);
+
+        assertTrue((boolean) method.invoke(poller, m1));
+        assertFalse((boolean) method.invoke(poller, m2));
+    }
+}

--- a/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPollerTest.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/inbound/SQSPollerTest.java
@@ -127,7 +127,9 @@ class SQSPollerTest {
             mockedIoUtils.when(() -> software.amazon.awssdk.utils.IoUtils.toUtf8String(responseInputStream))
                     .thenReturn(s3Content);
 
-            Message updated = poller.fetchS3MessageContent(origMsg);
+            var method = SQSPoller.class.getDeclaredMethod("fetchS3MessageContent", Message.class);
+            method.setAccessible(true);
+            Message updated = (Message) method.invoke(poller, origMsg);
 
             assertNotNull(updated);
             assertEquals(s3Content, updated.body());
@@ -145,7 +147,9 @@ class SQSPollerTest {
         poller = new SQSPoller(spec, ctx, factory);
 
         // Should not throw, should return original message
-        Message result = poller.fetchS3MessageContent(origMsg);
+        var method = SQSPoller.class.getDeclaredMethod("fetchS3MessageContent", Message.class);
+        method.setAccessible(true);
+        Message result = (Message) method.invoke(poller, origMsg);
         assertEquals(origMsg, result);
     }
 

--- a/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSConnectionFactoryImplTest.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSConnectionFactoryImplTest.java
@@ -1,0 +1,110 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.amazonsqs.api.outbound;
+
+import fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSConnection;
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ConnectionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AmazonSQSConnectionFactoryImplTest {
+
+    private ConnectionManager connectionManager;
+    private AmazonSQSManagedConnectionFactory managedConnectionFactory;
+    private AmazonSQSConnectionFactoryImpl factoryImpl;
+
+    @BeforeEach
+    void setUp() {
+        connectionManager = mock(ConnectionManager.class);
+        managedConnectionFactory = mock(AmazonSQSManagedConnectionFactory.class);
+    }
+
+    @Test
+    void testGetConnectionWithConnectionManager() throws ResourceException {
+        AmazonSQSConnection mockConnection = mock(AmazonSQSConnection.class);
+        when(connectionManager.allocateConnection(managedConnectionFactory, null)).thenReturn(mockConnection);
+
+        factoryImpl = new AmazonSQSConnectionFactoryImpl(connectionManager, managedConnectionFactory);
+        AmazonSQSConnection connection = factoryImpl.getConnection();
+
+        assertNotNull(connection);
+        assertEquals(mockConnection, connection);
+        verify(connectionManager).allocateConnection(managedConnectionFactory, null);
+    }
+
+    @Test
+    void testGetConnectionWithConnectionManagerThrowsException() throws ResourceException {
+        when(connectionManager.allocateConnection(managedConnectionFactory, null)).thenThrow(new ResourceException("fail"));
+
+        factoryImpl = new AmazonSQSConnectionFactoryImpl(connectionManager, managedConnectionFactory);
+        AmazonSQSConnection connection = factoryImpl.getConnection();
+
+        assertNull(connection);
+        verify(connectionManager).allocateConnection(managedConnectionFactory, null);
+    }
+
+    @Test
+    void testGetConnectionWithoutConnectionManager() throws ResourceException {
+        AmazonSQSManagedConnection managedConnection = mock(AmazonSQSManagedConnection.class);
+        when(managedConnectionFactory.createManagedConnection(null, null)).thenReturn(managedConnection);
+
+        factoryImpl = new AmazonSQSConnectionFactoryImpl(null, managedConnectionFactory);
+        AmazonSQSConnection connection = factoryImpl.getConnection();
+
+        assertNotNull(connection);
+        assertEquals(managedConnection, connection);
+        verify(managedConnectionFactory).createManagedConnection(null, null);
+    }
+
+    @Test
+    void testGetConnectionWithoutConnectionManagerThrowsException() throws ResourceException {
+        when(managedConnectionFactory.createManagedConnection(null, null)).thenThrow(new ResourceException("fail"));
+
+        factoryImpl = new AmazonSQSConnectionFactoryImpl(null, managedConnectionFactory);
+        AmazonSQSConnection connection = factoryImpl.getConnection();
+
+        assertNull(connection);
+        verify(managedConnectionFactory).createManagedConnection(null, null);
+    }
+}

--- a/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactoryTest.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionFactoryTest.java
@@ -1,0 +1,157 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.amazonsqs.api.outbound;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ConnectionManager;
+import jakarta.resource.spi.ConnectionRequestInfo;
+import jakarta.resource.spi.ManagedConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.security.auth.Subject;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AmazonSQSManagedConnectionFactoryTest {
+
+    private AmazonSQSManagedConnectionFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new AmazonSQSManagedConnectionFactory();
+    }
+
+    @Test
+    void testSettersAndGetters() {
+        factory.setAwsSecretKey("secret");
+        factory.setAwsAccessKeyId("access");
+        factory.setRegion("us-east-1");
+        factory.setProfileName("profile");
+        factory.setRoleArn("arn:aws:iam::123456789012:role/test");
+        factory.setRoleSessionName("session");
+        factory.setS3BucketName("bucket");
+        factory.setS3SizeThreshold(100);
+        factory.setS3KeyPrefix("prefix/");
+        factory.setS3FetchMessage(false);
+
+        assertEquals("secret", factory.getAwsSecretKey());
+        assertEquals("access", factory.getAwsAccessKeyId());
+        assertEquals("us-east-1", factory.getRegion());
+        assertEquals("profile", factory.getProfileName());
+        assertEquals("arn:aws:iam::123456789012:role/test", factory.getRoleArn());
+        assertEquals("session", factory.getRoleSessionName());
+        assertEquals("bucket", factory.getS3BucketName());
+        assertEquals(100, factory.getS3SizeThreshold());
+        assertEquals("prefix/", factory.getS3KeyPrefix());
+        assertFalse(factory.getS3FetchMessage());
+    }
+
+    @Test
+    void testCreateConnectionFactoryWithManager() throws ResourceException {
+        ConnectionManager cm = mock(ConnectionManager.class);
+        Object cf = factory.createConnectionFactory(cm);
+        assertNotNull(cf);
+        assertTrue(cf instanceof AmazonSQSConnectionFactoryImpl);
+    }
+
+    @Test
+    void testCreateConnectionFactoryWithoutManager() throws ResourceException {
+        Object cf = factory.createConnectionFactory();
+        assertNotNull(cf);
+        assertTrue(cf instanceof AmazonSQSConnectionFactoryImpl);
+    }
+
+    @Test
+    void testCreateManagedConnection() throws ResourceException {
+        factory.setRegion("us-east-1"); 
+        Subject subject = new Subject();
+        ConnectionRequestInfo info = mock(ConnectionRequestInfo.class);
+        ManagedConnection mc = factory.createManagedConnection(subject, info);
+        assertNotNull(mc);
+        assertTrue(mc instanceof AmazonSQSManagedConnection);
+    }
+
+    @Test
+    void testMatchManagedConnections() throws ResourceException {
+        ManagedConnection mc = mock(ManagedConnection.class);
+        Set<ManagedConnection> set = new HashSet<>();
+        set.add(mc);
+        ManagedConnection matched = factory.matchManagedConnections(set, null, null);
+        assertEquals(mc, matched);
+    }
+
+    @Test
+    void testSetAndGetLogWriter() throws ResourceException {
+        PrintWriter pw = new PrintWriter(System.out);
+        factory.setLogWriter(pw);
+        assertEquals(pw, factory.getLogWriter());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        AmazonSQSManagedConnectionFactory f1 = new AmazonSQSManagedConnectionFactory();
+        AmazonSQSManagedConnectionFactory f2 = new AmazonSQSManagedConnectionFactory();
+
+        f1.setAwsSecretKey("secret");
+        f1.setAwsAccessKeyId("access");
+        f1.setRegion("region");
+        f1.setProfileName("profile");
+        f1.setRoleArn("roleArn");
+        f1.setRoleSessionName("session");
+
+        f2.setAwsSecretKey("secret");
+        f2.setAwsAccessKeyId("access");
+        f2.setRegion("region");
+        f2.setProfileName("profile");
+        f2.setRoleArn("roleArn");
+        f2.setRoleSessionName("session");
+
+        assertEquals(f1, f2);
+        assertEquals(f1.hashCode(), f2.hashCode());
+
+        f2.setRoleSessionName("different");
+        assertNotEquals(f1, f2);
+    }
+}

--- a/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionTest.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionTest.java
@@ -1,0 +1,238 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.amazonsqs.api.outbound;
+
+import com.amazon.sqs.javamessaging.AmazonSQSExtendedClient;
+import fish.payara.cloud.connectors.amazonsqs.api.AmazonSQSConnection;
+import jakarta.resource.NotSupportedException;
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ConnectionEvent;
+import jakarta.resource.spi.ConnectionEventListener;
+import jakarta.resource.spi.ConnectionRequestInfo;
+import jakarta.resource.spi.ManagedConnectionMetaData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import javax.security.auth.Subject;
+import java.io.PrintWriter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AmazonSQSManagedConnectionTest {
+
+    private AmazonSQSManagedConnectionFactory factory;
+    private Subject subject;
+    private ConnectionRequestInfo cxRequestInfo;
+
+    @BeforeEach
+    void setUp() {
+        factory = mock(AmazonSQSManagedConnectionFactory.class);
+        when(factory.getRegion()).thenReturn("us-east-1");
+        when(factory.getAwsAccessKeyId()).thenReturn("access");
+        when(factory.getAwsSecretKey()).thenReturn("secret");
+        when(factory.getProfileName()).thenReturn(null);
+        when(factory.getRoleArn()).thenReturn(null);
+        when(factory.getRoleSessionName()).thenReturn(null);
+        when(factory.getS3BucketName()).thenReturn(null);
+        when(factory.getS3SizeThreshold()).thenReturn(null);
+        when(factory.getS3KeyPrefix()).thenReturn(null);
+
+        subject = new Subject();
+        cxRequestInfo = mock(ConnectionRequestInfo.class);
+    }
+
+    @Test
+    void testGetConnectionAddsHandle() throws ResourceException {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        AmazonSQSConnection handle = (AmazonSQSConnection) conn.getConnection(subject, cxRequestInfo);
+        assertNotNull(handle);
+    }
+
+    @Test
+    void testCleanupClearsHandles() throws ResourceException {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        conn.getConnection(subject, cxRequestInfo);
+        conn.cleanup();
+        // No exception means success; internal handles list is cleared
+    }
+
+    @Test
+    void testAssociateConnectionAddsHandle() throws ResourceException {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        AmazonSQSConnectionImpl mockConn = mock(AmazonSQSConnectionImpl.class);
+        conn.associateConnection(mockConn);
+        verify(mockConn).setRealConnection(conn);
+    }
+
+    @Test
+    void testAddAndRemoveConnectionEventListener() {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        ConnectionEventListener listener = mock(ConnectionEventListener.class);
+        conn.addConnectionEventListener(listener);
+        conn.removeConnectionEventListener(listener);
+        // No exception means listeners set is managed
+    }
+
+    @Test
+    void testRemoveHandleFiresEvent() {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        ConnectionEventListener listener = mock(ConnectionEventListener.class);
+        conn.addConnectionEventListener(listener);
+        AmazonSQSConnectionImpl mockConn = mock(AmazonSQSConnectionImpl.class);
+        conn.removeHandle(mockConn);
+        verify(listener).connectionClosed(any(ConnectionEvent.class));
+    }
+
+    @Test
+    void testGetMetaData() throws ResourceException {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        ManagedConnectionMetaData meta = conn.getMetaData();
+        assertEquals("Amazon SQS JCA Adapter", meta.getEISProductName());
+        assertEquals("1.0.0", meta.getEISProductVersion());
+        assertEquals(0, meta.getMaxConnections());
+        assertEquals("anonymous", meta.getUserName());
+    }
+
+    @Test
+    void testSetAndGetLogWriter() throws ResourceException {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        PrintWriter pw = new PrintWriter(System.out);
+        conn.setLogWriter(pw);
+        assertEquals(pw, conn.getLogWriter());
+    }
+
+    @Test
+    void testXAResourceAndLocalTransactionNotSupported() {
+        AmazonSQSManagedConnection conn = new AmazonSQSManagedConnection(subject, cxRequestInfo, factory);
+        assertThrows(NotSupportedException.class, conn::getXAResource);
+        assertThrows(NotSupportedException.class, conn::getLocalTransaction);
+    }
+
+    @Test
+    void testSendMessageDelegatesToCorrectClient() {
+        AmazonSQSManagedConnectionFactory fac = mock(AmazonSQSManagedConnectionFactory.class);
+        when(fac.getRegion()).thenReturn("us-east-1");
+        when(fac.getAwsAccessKeyId()).thenReturn("access");
+        when(fac.getAwsSecretKey()).thenReturn("secret");
+        when(fac.getProfileName()).thenReturn(null);
+        when(fac.getRoleArn()).thenReturn(null);
+        when(fac.getRoleSessionName()).thenReturn(null);
+        when(fac.getS3BucketName()).thenReturn(null);
+        when(fac.getS3SizeThreshold()).thenReturn(null);
+        when(fac.getS3KeyPrefix()).thenReturn(null);
+
+        // Use a spy to override isLargeMessage
+        AmazonSQSManagedConnection conn = spy(new AmazonSQSManagedConnection(subject, cxRequestInfo, fac));
+        SendMessageRequest req = SendMessageRequest.builder().queueUrl("url").messageBody("short").build();
+        doReturn(false).when(conn).isLargeMessage(anyString());
+
+        // Mock SqsClient and AmazonSQSExtendedClient
+        SqsClient sqsClient = mock(SqsClient.class);
+        AmazonSQSExtendedClient extClient = mock(AmazonSQSExtendedClient.class);
+        // Use reflection to set private fields
+        try {
+            var sqsField = AmazonSQSManagedConnection.class.getDeclaredField("sqsClient");
+            sqsField.setAccessible(true);
+            sqsField.set(conn, sqsClient);
+            var extField = AmazonSQSManagedConnection.class.getDeclaredField("sqsExtClient");
+            extField.setAccessible(true);
+            extField.set(conn, extClient);
+        } catch (Exception e) {
+            fail("Reflection failed: " + e.getMessage());
+        }
+
+        SendMessageResponse resp = SendMessageResponse.builder().messageId("id").build();
+        when(sqsClient.sendMessage(any(SendMessageRequest.class))).thenReturn(resp);
+
+        SendMessageResponse result = conn.sendMessage(req);
+        assertEquals("id", result.messageId());
+        verify(sqsClient).sendMessage(req);
+        verify(extClient, never()).sendMessage(any(SendMessageRequest.class));
+    }
+
+    @Test
+    void testSendMessageLargeDelegatesToExtendedClient() {
+        AmazonSQSManagedConnectionFactory fac = mock(AmazonSQSManagedConnectionFactory.class);
+        when(fac.getRegion()).thenReturn("us-east-1");
+        when(fac.getAwsAccessKeyId()).thenReturn("access");
+        when(fac.getAwsSecretKey()).thenReturn("secret");
+        when(fac.getProfileName()).thenReturn(null);
+        when(fac.getRoleArn()).thenReturn(null);
+        when(fac.getRoleSessionName()).thenReturn(null);
+        when(fac.getS3BucketName()).thenReturn(null);
+        when(fac.getS3SizeThreshold()).thenReturn(null);
+        when(fac.getS3KeyPrefix()).thenReturn(null);
+
+        AmazonSQSManagedConnection conn = spy(new AmazonSQSManagedConnection(subject, cxRequestInfo, fac));
+        SendMessageRequest req = SendMessageRequest.builder().queueUrl("url").messageBody("large message").build();
+        doReturn(true).when(conn).isLargeMessage(anyString());
+
+        SqsClient sqsClient = mock(SqsClient.class);
+        AmazonSQSExtendedClient extClient = mock(AmazonSQSExtendedClient.class);
+        try {
+            var sqsField = AmazonSQSManagedConnection.class.getDeclaredField("sqsClient");
+            sqsField.setAccessible(true);
+            sqsField.set(conn, sqsClient);
+            var extField = AmazonSQSManagedConnection.class.getDeclaredField("sqsExtClient");
+            extField.setAccessible(true);
+            extField.set(conn, extClient);
+        } catch (Exception e) {
+            fail("Reflection failed: " + e.getMessage());
+        }
+
+        SendMessageResponse resp = SendMessageResponse.builder().messageId("id2").build();
+        when(extClient.sendMessage(any(SendMessageRequest.class))).thenReturn(resp);
+
+        SendMessageResponse result = conn.sendMessage(req);
+        assertEquals("id2", result.messageId());
+        verify(extClient).sendMessage(req);
+        verify(sqsClient, never()).sendMessage(any(SendMessageRequest.class));
+    }
+
+    @Test
+    void testCloseCallsDestroy() throws Exception {
+        AmazonSQSManagedConnection conn = spy(new AmazonSQSManagedConnection(subject, cxRequestInfo, factory));
+        conn.close();
+        verify(conn).destroy();
+    }
+}

--- a/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionTest.java
+++ b/AmazonSQS/AmazonSQSJCAAPI/src/test/java/fish/payara/cloud/connectors/amazonsqs/api/outbound/AmazonSQSManagedConnectionTest.java
@@ -56,6 +56,7 @@ import javax.security.auth.Subject;
 import java.io.PrintWriter;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class AmazonSQSManagedConnectionTest {
@@ -161,10 +162,9 @@ class AmazonSQSManagedConnectionTest {
         when(fac.getS3SizeThreshold()).thenReturn(null);
         when(fac.getS3KeyPrefix()).thenReturn(null);
 
-        // Use a spy to override isLargeMessage
         AmazonSQSManagedConnection conn = spy(new AmazonSQSManagedConnection(subject, cxRequestInfo, fac));
         SendMessageRequest req = SendMessageRequest.builder().queueUrl("url").messageBody("short").build();
-        doReturn(false).when(conn).isLargeMessage(anyString());
+        //doReturn(false).when(conn).isLargeMessage(anyString());
 
         // Mock SqsClient and AmazonSQSExtendedClient
         SqsClient sqsClient = mock(SqsClient.class);
@@ -203,9 +203,16 @@ class AmazonSQSManagedConnectionTest {
         when(fac.getS3SizeThreshold()).thenReturn(null);
         when(fac.getS3KeyPrefix()).thenReturn(null);
 
+        // Generate a string > 256KB to be considered a large message
+        int size = 262145;
+        StringBuilder sb = new StringBuilder(size);
+        for (int i = 0; i < size; i++) {
+            sb.append('A');
+        }
+        String largeMessage = sb.toString();
+
         AmazonSQSManagedConnection conn = spy(new AmazonSQSManagedConnection(subject, cxRequestInfo, fac));
-        SendMessageRequest req = SendMessageRequest.builder().queueUrl("url").messageBody("large message").build();
-        doReturn(true).when(conn).isLargeMessage(anyString());
+        SendMessageRequest req = SendMessageRequest.builder().queueUrl("url").messageBody(largeMessage).build();
 
         SqsClient sqsClient = mock(SqsClient.class);
         AmazonSQSExtendedClient extClient = mock(AmazonSQSExtendedClient.class);


### PR DESCRIPTION
PR to add unit tests to some classes for the connector to Amazon SQS
I only focused on the classes having most of the "logic". 

Other connectors shall be covered in future tasks.
At the moment, the project Cloud Connectors does not have a pipeline in Jenkins. When it will, I shall integrate a step to run these tests with each new build.