### PR TITLE
FISH-12118 unit test azure

### DIFF
--- a/AzureServiceBus/AzureSBJCAAPI/pom.xml
+++ b/AzureServiceBus/AzureSBJCAAPI/pom.xml
@@ -23,5 +23,32 @@
             <artifactId>azure-management</artifactId>
             <version>0.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.13.4</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.20.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBActivationSpecTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBActivationSpecTest.java
@@ -1,0 +1,117 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.azuresb.api.inbound;
+
+import jakarta.resource.spi.InvalidPropertyException;
+import jakarta.resource.spi.ResourceAdapter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AzureSBActivationSpecTest {
+
+    @Test
+    void testSettersAndGetters() {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        spec.setQueueName("queue1");
+        spec.setSasKey("sas-key-value");
+        spec.setSasKeyName("sas-key-name");
+        spec.setNameSpace("test-namespace");
+        assertEquals("queue1", spec.getQueueName());
+        assertEquals("sas-key-value", spec.getSasKey());
+        assertEquals("sas-key-name", spec.getSasKeyName());
+        assertEquals("test-namespace", spec.getNameSpace());
+    }
+
+    @Test
+    void testValidateThrowsIfQueueNameNull() {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        spec.setSasKey("sas-key-value");
+        spec.setSasKeyName("sas-key-name");
+        spec.setNameSpace("test-namespace");
+        assertThrows(InvalidPropertyException.class, spec::validate);
+    }
+
+    @Test
+    void testValidateThrowsIfSasKeyNull() {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        spec.setQueueName("queue1");
+        spec.setSasKeyName("sas-key-name");
+        spec.setNameSpace("test-namespace");
+        assertThrows(InvalidPropertyException.class, spec::validate);
+    }
+
+    @Test
+    void testValidateThrowsIfSasKeyNameNull() {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        spec.setQueueName("queue1");
+        spec.setSasKey("sas-key-value");
+        spec.setNameSpace("test-namespace");
+        assertThrows(InvalidPropertyException.class, spec::validate);
+    }
+
+    @Test
+    void testValidateThrowsIfNamespaceNull() {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        spec.setQueueName("queue1");
+        spec.setSasKey("sas-key-value");
+        spec.setSasKeyName("sas-key-name");
+        assertThrows(InvalidPropertyException.class, spec::validate);
+    }
+
+    @Test
+    void testValidateSucceedsIfAllSet() {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        spec.setQueueName("queue1");
+        spec.setSasKey("sas-key-value");
+        spec.setSasKeyName("sas-key-name");
+        spec.setNameSpace("test-namespace");
+        assertDoesNotThrow(spec::validate);
+    }
+
+    @Test
+    void testResourceAdapterSetAndGet() throws Exception {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        ResourceAdapter adapter = mock(ResourceAdapter.class);
+        spec.setResourceAdapter(adapter);
+        assertEquals(adapter, spec.getResourceAdapter());
+    }
+}

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBResourceAdapterTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBResourceAdapterTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Disabled;
 import static org.mockito.Mockito.*;
-import org.mockito.Mockito;
 
 class AzureSBResourceAdapterTest {
 

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBResourceAdapterTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBResourceAdapterTest.java
@@ -1,0 +1,109 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.azuresb.api.inbound;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ActivationSpec;
+import jakarta.resource.spi.BootstrapContext;
+import jakarta.resource.spi.ResourceAdapterInternalException;
+import jakarta.resource.spi.endpoint.MessageEndpointFactory;
+import java.util.Timer;
+import javax.transaction.xa.XAResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import org.mockito.Mockito;
+
+class AzureSBResourceAdapterTest {
+
+    private AzureSBResourceAdapter adapter;
+    private BootstrapContext bootstrapContext;
+    private MessageEndpointFactory endpointFactory;
+    private ActivationSpec activationSpec;
+    private AzureSBListener listener;
+    private Timer poller;
+
+    @BeforeEach
+    void setUp() throws ResourceAdapterInternalException, ResourceException {
+        adapter = new AzureSBResourceAdapter();
+        bootstrapContext = mock(BootstrapContext.class);
+        endpointFactory = mock(MessageEndpointFactory.class);
+        activationSpec = mock(ActivationSpec.class);
+        listener = mock(AzureSBListener.class);
+        poller = mock(Timer.class);
+
+        when(endpointFactory.getEndpointClass()).thenAnswer(invocation -> Object.class);
+        when(bootstrapContext.getWorkManager()).thenReturn(mock(jakarta.resource.spi.work.WorkManager.class));
+        doNothing().when(listener).subscribe();
+        doNothing().when(listener).close();
+        adapter.start(bootstrapContext);
+    }
+
+    @Test
+    void testStartSetsContext() throws Exception {
+        var contextField = AzureSBResourceAdapter.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        assertEquals(bootstrapContext, contextField.get(adapter));
+    }
+
+    @Test
+    void testStopDoesNotThrow() {
+        assertDoesNotThrow(() -> adapter.stop());
+    }
+
+    @Test
+    void testEndpointActivationAndDeactivation() {
+        AzureSBActivationSpec spec = new AzureSBActivationSpec();
+        spec.setQueueName("queue1");
+        spec.setSasKey("sas-key-value");
+        spec.setSasKeyName("sas-key-name");
+        spec.setNameSpace("test-namespace");
+        assertDoesNotThrow(() -> adapter.endpointActivation(endpointFactory, spec));
+        assertDoesNotThrow(() -> adapter.endpointDeactivation(endpointFactory, spec));
+    }
+
+    @Test
+    void testGetXAResourcesReturnsNull() throws Exception {
+        XAResource[] result = adapter.getXAResources(new ActivationSpec[0]);
+        assertNull(result);
+    }
+}

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBResourceAdapterTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/inbound/AzureSBResourceAdapterTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Disabled;
 import static org.mockito.Mockito.*;
 import org.mockito.Mockito;
 
@@ -73,8 +74,6 @@ class AzureSBResourceAdapterTest {
 
         when(endpointFactory.getEndpointClass()).thenAnswer(invocation -> Object.class);
         when(bootstrapContext.getWorkManager()).thenReturn(mock(jakarta.resource.spi.work.WorkManager.class));
-        doNothing().when(listener).subscribe();
-        doNothing().when(listener).close();
         adapter.start(bootstrapContext);
     }
 
@@ -85,11 +84,13 @@ class AzureSBResourceAdapterTest {
         assertEquals(bootstrapContext, contextField.get(adapter));
     }
 
+    @Disabled("Cannot mock poller.cancel() in AzureSBResourceAdapter")
     @Test
     void testStopDoesNotThrow() {
         assertDoesNotThrow(() -> adapter.stop());
     }
 
+    @Disabled("Cannot mock sbListener.subscribe() in AzureSBResourceAdapter")
     @Test
     void testEndpointActivationAndDeactivation() {
         AzureSBActivationSpec spec = new AzureSBActivationSpec();

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBConnectionFactoryImplTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBConnectionFactoryImplTest.java
@@ -1,0 +1,88 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.azuresb.api.outbound;
+
+import fish.payara.cloud.connectors.azuresb.api.AzureSBConnection;
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ConnectionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AzureSBConnectionFactoryImplTest {
+
+    private ConnectionManager connectionManager;
+    private AzureSBManagedConnectionFactory managedConnectionFactory;
+    private AzureSBConnectionFactoryImpl factoryImpl;
+
+    @BeforeEach
+    void setUp() {
+        connectionManager = mock(ConnectionManager.class);
+        managedConnectionFactory = mock(AzureSBManagedConnectionFactory.class);
+    }
+
+    @Test
+    void testGetConnectionWithConnectionManager() throws ResourceException {
+        AzureSBConnectionImpl mockConnection = mock(AzureSBConnectionImpl.class);
+        when(connectionManager.allocateConnection(managedConnectionFactory, null)).thenReturn(mockConnection);
+
+        factoryImpl = new AzureSBConnectionFactoryImpl(managedConnectionFactory, connectionManager);
+        AzureSBConnection connection = factoryImpl.getConnection();
+
+        assertNotNull(connection);
+        assertEquals(mockConnection, connection);
+        verify(connectionManager).allocateConnection(managedConnectionFactory, null);
+    }
+
+    @Test
+    void testGetConnectionWithoutConnectionManager() throws ResourceException {
+        var managedConnection = mock(AzureSBManagedConnection.class);
+        when(managedConnectionFactory.createManagedConnection(null, null)).thenReturn(managedConnection);
+
+        factoryImpl = new AzureSBConnectionFactoryImpl(managedConnectionFactory, null);
+        AzureSBConnection connection = factoryImpl.getConnection();
+
+        assertNotNull(connection);
+        assertEquals(managedConnection, connection);
+        verify(managedConnectionFactory).createManagedConnection(null, null);
+    }
+}

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBConnectionImplTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBConnectionImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.azuresb.api.outbound;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AzureSBConnectionImplTest {
+
+    private AzureSBManagedConnection managedConnection;
+    private AzureSBConnectionImpl connectionImpl;
+
+    @BeforeEach
+    void setUp() {
+        managedConnection = mock(AzureSBManagedConnection.class);
+        connectionImpl = new AzureSBConnectionImpl(managedConnection);
+    }
+
+    @Test
+    void testCloseCallsRemoveHandle() throws Exception {
+        doNothing().when(managedConnection).removeHandle(connectionImpl);
+        connectionImpl.close();
+        verify(managedConnection).removeHandle(connectionImpl);
+    }
+
+    @Test
+    void testSetRealConnection() {
+        AzureSBManagedConnection newConn = mock(AzureSBManagedConnection.class);
+        assertDoesNotThrow(() -> connectionImpl.setRealConnection(newConn));
+    }
+
+    @Test
+    void testToStringAndEquals() {
+        assertNotNull(connectionImpl.toString());
+        assertNotEquals(connectionImpl, new Object());
+    }
+}

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBManagedConnectionFactoryTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBManagedConnectionFactoryTest.java
@@ -1,0 +1,92 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.azuresb.api.outbound;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ConnectionManager;
+import jakarta.resource.spi.ConnectionRequestInfo;
+import jakarta.resource.spi.ManagedConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.security.auth.Subject;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AzureSBManagedConnectionFactoryTest {
+
+    private AzureSBManagedConnectionFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new AzureSBManagedConnectionFactory();
+        factory.setQueueName("queue1");
+        factory.setSasKey("sas-key-value");
+        factory.setSasKeyName("sas-key-name");
+        factory.setNameSpace("test-namespace");
+        factory.setTimeOut(1000);
+    }
+
+    @Test
+    void testCreateConnectionFactoryWithManager() throws ResourceException {
+        ConnectionManager cm = mock(ConnectionManager.class);
+        Object cf = factory.createConnectionFactory(cm);
+        assertNotNull(cf);
+        assertTrue(cf instanceof AzureSBConnectionFactoryImpl);
+    }
+
+    @Test
+    void testCreateConnectionFactoryWithoutManager() throws ResourceException {
+        Object cf = factory.createConnectionFactory();
+        assertNotNull(cf);
+        assertTrue(cf instanceof AzureSBConnectionFactoryImpl);
+    }
+
+    @Test
+    void testCreateManagedConnection() throws Exception {
+        Subject subject = new Subject();
+        ConnectionRequestInfo info = mock(ConnectionRequestInfo.class);
+        ManagedConnection mc = factory.createManagedConnection(subject, info);
+        assertNotNull(mc);
+        assertTrue(mc instanceof AzureSBManagedConnection);
+    }
+
+}

--- a/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBManagedConnectionTest.java
+++ b/AzureServiceBus/AzureSBJCAAPI/src/test/java/fish/payara/cloud/connectors/azuresb/api/outbound/AzureSBManagedConnectionTest.java
@@ -1,0 +1,111 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.cloud.connectors.azuresb.api.outbound;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ConnectionEventListener;
+import jakarta.resource.spi.ConnectionRequestInfo;
+import jakarta.resource.spi.ManagedConnectionMetaData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.security.auth.Subject;
+import java.io.PrintWriter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AzureSBManagedConnectionTest {
+
+    private AzureSBManagedConnectionFactory factory;
+    private AzureSBManagedConnection managedConnection;
+
+    @BeforeEach
+    void setUp() {
+        factory = new AzureSBManagedConnectionFactory();
+        factory.setQueueName("queue1");
+        factory.setSasKey("sas-key-value");
+        factory.setSasKeyName("sas-key-name");
+        factory.setNameSpace("test-namespace");
+        factory.setTimeOut(1000);
+        managedConnection = new AzureSBManagedConnection(factory, new Subject(), mock(ConnectionRequestInfo.class));
+    }
+
+    @Test
+    void testGetMetaData() throws Exception {
+        ManagedConnectionMetaData meta = managedConnection.getMetaData();
+        assertNotNull(meta);
+        assertEquals("Azure SB JCA Adapter", meta.getEISProductName());
+    }
+
+    @Test
+    void testSetAndGetLogWriter() throws Exception {
+        PrintWriter pw = new PrintWriter(System.out);
+        managedConnection.setLogWriter(pw);
+        assertEquals(pw, managedConnection.getLogWriter());
+    }
+
+    @Test
+    void testCleanupAndDestroy() {
+        assertDoesNotThrow(() -> managedConnection.cleanup());
+        assertDoesNotThrow(() -> managedConnection.destroy());
+    }
+
+    @Test
+    void testAddAndRemoveConnectionEventListener() {
+        ConnectionEventListener listener = mock(ConnectionEventListener.class);
+        managedConnection.addConnectionEventListener(listener);
+        managedConnection.removeConnectionEventListener(listener);
+    }
+
+    @Test
+    void testAssociateConnection() {
+        AzureSBManagedConnection managedConnection2 = mock(AzureSBManagedConnection.class);
+        AzureSBConnectionImpl connection = new AzureSBConnectionImpl(managedConnection2);
+        assertDoesNotThrow(() -> managedConnection.associateConnection(connection));
+    }
+
+    @Test
+    void testGetConnectionReturnsAzureSBConnectionImpl() throws ResourceException {
+        Object conn = managedConnection.getConnection(null, null);
+        assertNotNull(conn);
+        assertTrue(conn instanceof AzureSBConnectionImpl);
+    }
+}


### PR DESCRIPTION
Unit tests for Azure API.
Some tests are disabled (instead of removed) because I could not mock some parts. It leaves some room for improvement in a distant future.